### PR TITLE
Increase use of available RAM in docker

### DIFF
--- a/packages/Manager/Dockerfile
+++ b/packages/Manager/Dockerfile
@@ -8,9 +8,8 @@ FROM eclipse-temurin:18
 WORKDIR application
 COPY --from=builder application/dependencies/ ./
 COPY --from=builder application/spring-boot-loader/ ./
-#COPY --from=builder application/snapshot-dependencies/ ./
 COPY --from=builder application/application/ ./
-ENTRYPOINT ["java", "org.springframework.boot.loader.JarLauncher"]
+ENTRYPOINT ["java", "-XX:MaxRAMPercentage=90", "org.springframework.boot.loader.JarLauncher"]
 
 EXPOSE 8080
 HEALTHCHECK --interval=5s --retries=5 --start-period=60s CMD curl --fail http://localhost:8080/actuator/health || exit 1


### PR DESCRIPTION
By default JVM will only use 25% of available memory without this setting. 

Was making inefficient use of resources when deployed to AWS, having to drastically increase the memory on AWS to get more used.