### PR TITLE
bug: change alloc data to surfacewater row

### DIFF
--- a/packages/Manager/src/main/resources/db/migration/V0006__update_allocation_data.sql
+++ b/packages/Manager/src/main/resources/db/migration/V0006__update_allocation_data.sql
@@ -1,0 +1,151 @@
+UPDATE
+  allocation_amounts
+SET
+  allocation_amount = NULL,
+  allocation_amount_unit = ''
+WHERE
+  id = 45;
+
+UPDATE
+  allocation_amounts
+SET
+  allocation_amount = NULL,
+  allocation_amount_unit = ''
+WHERE
+  id = 46;
+
+UPDATE
+  allocation_amounts
+SET
+  allocation_amount = NULL,
+  allocation_amount_unit = ''
+WHERE
+  id = 47;
+
+UPDATE
+  allocation_amounts
+SET
+  allocation_amount = NULL,
+  allocation_amount_unit = ''
+WHERE
+  id = 48;
+
+UPDATE
+  allocation_amounts
+SET
+  allocation_amount = NULL,
+  allocation_amount_unit = ''
+WHERE
+  id = 49;
+
+UPDATE
+  allocation_amounts
+SET
+  allocation_amount = NULL,
+  allocation_amount_unit = ''
+WHERE
+  id = 50;
+
+UPDATE
+  allocation_amounts
+SET
+  allocation_amount = NULL,
+  allocation_amount_unit = ''
+WHERE
+  id = 51;
+
+UPDATE
+  allocation_amounts
+SET
+  allocation_amount = NULL,
+  allocation_amount_unit = ''
+WHERE
+  id = 52;
+
+UPDATE
+  allocation_amounts
+SET
+  allocation_amount = NULL,
+  allocation_amount_unit = ''
+WHERE
+  id = 53;
+
+UPDATE
+  allocation_amounts
+SET
+  allocation_amount = NULL,
+  allocation_amount_unit = ''
+WHERE
+  id = 54;
+
+UPDATE
+  allocation_amounts
+SET
+  allocation_amount = 1200,
+  allocation_amount_unit = 'L/s'
+WHERE
+  id = 20;
+
+UPDATE
+  allocation_amounts
+SET
+  allocation_amount = 1240,
+  allocation_amount_unit = 'L/s'
+WHERE
+  id = 26;
+
+UPDATE
+  allocation_amounts
+SET
+  allocation_amount = 110,
+  allocation_amount_unit = 'L/s'
+WHERE
+  id = 27;
+
+UPDATE
+  allocation_amounts
+SET
+  allocation_amount = 1370,
+  allocation_amount_unit = 'L/s'
+WHERE
+  id = 28;
+
+UPDATE
+  allocation_amounts
+SET
+  allocation_amount = 410,
+  allocation_amount_unit = 'L/s'
+WHERE
+  id = 31;
+
+UPDATE
+  allocation_amounts
+SET
+  allocation_amount = 2140,
+  allocation_amount_unit = 'L/s'
+WHERE
+  id = 32;
+
+UPDATE
+  allocation_amounts
+SET
+  allocation_amount = 45,
+  allocation_amount_unit = 'L/s'
+WHERE
+  id = 37;
+
+UPDATE
+  allocation_amounts
+SET
+  allocation_amount = 590,
+  allocation_amount_unit = 'L/s'
+WHERE
+  id = 38;
+
+UPDATE
+  allocation_amounts
+SET
+  allocation_amount = 220,
+  allocation_amount_unit = 'L/s'
+WHERE
+  id = 40;


### PR DESCRIPTION
Moving allocation_amount data to the parent surface water row (it was previously on the groundwater row).

Surface water rows need the allocation_amount data for the app to work corrently. 