### PR TITLE
Martin/flow management site data changes

### DIFF
--- a/packages/Manager/src/main/resources/db/migration/V0015__minimum_flow_limits_changes.sql
+++ b/packages/Manager/src/main/resources/db/migration/V0015__minimum_flow_limits_changes.sql
@@ -3,17 +3,17 @@ SET surfacewater_subunit_name='Otukura Stream and tributaries above the confluen
 WHERE id=30;
 
 UPDATE minimum_flow_limits
-SET excluded_hydro_ids='{259497, 257578, 256291, 254602,259523}'
+SET excluded_hydro_ids='{259497, 257578, 256291, 254602,259523}', created_at = NOW()
 WHERE id=9;
 
 UPDATE minimum_flow_limits
-SET hydro_id = 259613
+SET hydro_id = 259613, created_at = NOW()
 WHERE id=6;
 
 UPDATE minimum_flow_limits
-SET excluded_hydro_ids='{260015,261930,262397,260343,258982,259960,262349,265528}' 
+SET excluded_hydro_ids='{260015,261930,262397,260343,258982,259960,262349,265528}', created_at = NOW()
 WHERE id=12;
 
 UPDATE minimum_flow_limits
-SET hydro_id = 262349
+SET hydro_id = 262349, created_at = NOW()
 WHERE id=10;

--- a/packages/Manager/src/main/resources/db/migration/V0015__minimum_flow_limits_changes.sql
+++ b/packages/Manager/src/main/resources/db/migration/V0015__minimum_flow_limits_changes.sql
@@ -11,7 +11,7 @@ SET hydro_id = 259613
 WHERE id=6;
 
 UPDATE minimum_flow_limits
-SET excluded_hydro_ids='{260015,261930,262397,260343,258982,259960,262349,262,268}' 
+SET excluded_hydro_ids='{260015,261930,262397,260343,258982,259960,262349,265528}' 
 WHERE id=12;
 
 UPDATE minimum_flow_limits

--- a/packages/Manager/src/main/resources/db/migration/V0015__minimum_flow_limits_changes.sql
+++ b/packages/Manager/src/main/resources/db/migration/V0015__minimum_flow_limits_changes.sql
@@ -1,0 +1,19 @@
+UPDATE allocation_amounts
+SET surfacewater_subunit_name='Otukura Stream and tributaries above the confluence with Dock/Stonestead Creek'
+WHERE id=30;
+
+UPDATE minimum_flow_limits
+SET excluded_hydro_ids='{259497, 257578, 256291, 254602,259523}'
+WHERE id=9;
+
+UPDATE minimum_flow_limits
+SET hydro_id = 259613
+WHERE id=6;
+
+UPDATE minimum_flow_limits
+SET excluded_hydro_ids='{260015,261930,262397,260343,258982,259960,262349,262,268}' 
+WHERE id=12;
+
+UPDATE minimum_flow_limits
+SET hydro_id = 262349
+WHERE id=10;


### PR DESCRIPTION
Data changes through database migrations

- changed starting hydroIds and hydroId exclusion data to make the minimum flow limit boundaries generate more accurately.
- small tidy up on how a surface water area is described