### PR TITLE
Update to show P121 in Waiarapa

### DIFF
--- a/packages/PlanLimitsUI/src/pages/Limits/LimitsTable.tsx
+++ b/packages/PlanLimitsUI/src/pages/Limits/LimitsTable.tsx
@@ -15,6 +15,7 @@ type Props = {
     Geometry,
     GroundwaterZoneBoundariesProperties
   >;
+  whaituaId: string;
 };
 
 export default function LimitsTable({
@@ -24,6 +25,7 @@ export default function LimitsTable({
   surfaceWaterMgmtSubUnitLimit,
   activeZonesIds,
   groundWaterZoneGeoJson,
+  whaituaId,
 }: Props) {
   const { headers, rows, showFootnote } = compileLimitsTable(
     waterTakeFilter,
@@ -31,7 +33,8 @@ export default function LimitsTable({
     surfaceWaterMgmtUnitLimit,
     surfaceWaterMgmtSubUnitLimit,
     activeZonesIds,
-    groundWaterZoneGeoJson
+    groundWaterZoneGeoJson,
+    whaituaId
   );
 
   if (rows.length === 0) return <></>;

--- a/packages/PlanLimitsUI/src/pages/Limits/compileLimitsTable.tsx
+++ b/packages/PlanLimitsUI/src/pages/Limits/compileLimitsTable.tsx
@@ -40,7 +40,8 @@ export default function compileLimitsTable(
   groundWaterZoneGeoJson: FeatureCollection<
     Geometry,
     GroundwaterZoneBoundariesProperties
-  >
+  >,
+  whaituaId: string
 ) {
   let showFootnote = false;
   const rows = [];
@@ -62,6 +63,8 @@ export default function compileLimitsTable(
         <>
           {surfaceWaterMgmtSubUnitLimit
             ? surfaceWaterMgmtSubUnitLimit
+            : whaituaId.toString() === '4'
+            ? DEFAULT_RULE
             : BLANK_CELL_CHAR}
         </>,
         surfaceWaterMgmtUnitLimit,

--- a/packages/PlanLimitsUI/src/pages/Limits/compileLimitsTable.tsx
+++ b/packages/PlanLimitsUI/src/pages/Limits/compileLimitsTable.tsx
@@ -37,7 +37,7 @@ export default function compileLimitsTable(
   surfaceWaterMgmtUnitLimit: string | null | undefined,
   surfaceWaterMgmtSubUnitLimit: string | null | undefined,
   activeZonesIds: Array<number>,
-  groundWaterZoneGeoJson: FeatureCollection<
+  groundwaterZoneGeoJson: FeatureCollection<
     Geometry,
     GroundwaterZoneBoundariesProperties
   >,
@@ -73,7 +73,7 @@ export default function compileLimitsTable(
   }
 
   if (['Combined', 'Ground'].includes(waterTakeFilter)) {
-    const activeFeatures = groundWaterZoneGeoJson.features
+    const activeFeatures = groundwaterZoneGeoJson.features
       .filter((item) => activeZonesIds.includes(Number(item.id as string)))
       .sort((a, b) => {
         // This specific sorting is ok because the set of values we have for Depths can always be sorted by the first character currently

--- a/packages/PlanLimitsUI/src/pages/Limits/compileLimitsTable.tsx
+++ b/packages/PlanLimitsUI/src/pages/Limits/compileLimitsTable.tsx
@@ -56,6 +56,8 @@ export default function compileLimitsTable(
         DEFAULT_RULE,
       ]);
     } else {
+      // Whaitua '4', the Waiarapa is hard coded here, because its uses 2 levels of surface water units
+      // and in areas where there is no value at the 'sub unit' level P121 applies
       rows.push([
         'Surface water',
         BLANK_CELL_CHAR,

--- a/packages/PlanLimitsUI/src/pages/Limits/sidebar.tsx
+++ b/packages/PlanLimitsUI/src/pages/Limits/sidebar.tsx
@@ -148,6 +148,7 @@ export default function Sidebar({
                 GroundwaterZoneBoundariesProperties
               >
             }
+            whaituaId={mouseState.whaituaId}
           />
         )}
       </div>


### PR DESCRIPTION
This PR make it show the P121 rule, in the Waiarapa Whaitua when there is a area that has no "Catchment Management Sub-Unit allocation" ... but it does have a "Catchment Management Unit:" allocation. Previously this would only display if there was a neither.

Ugly hard-coded Whaitua '4' ... feels like would be better driven from  config around how many catchment "levels" there are in this Whaitua