### PR TITLE
Refactor app state

### DIFF
--- a/packages/PlanLimitsUI/src/pages/Limits/defaultFlowLimitAndSite.spec.tsx
+++ b/packages/PlanLimitsUI/src/pages/Limits/defaultFlowLimitAndSite.spec.tsx
@@ -4,7 +4,7 @@ import defaultFlowLimitsAndSites from './defaultFlowLimitAndSite';
 
 describe('defaultFlowLimitsAndSites', () => {
   it('returns a link when the whaituaId is found', () => {
-    const result = defaultFlowLimitsAndSites('1');
+    const result = defaultFlowLimitsAndSites(1);
     const { getByRole } = render(result);
     const link = getByRole('link');
 
@@ -16,7 +16,7 @@ describe('defaultFlowLimitsAndSites', () => {
   });
 
   it('returns <>None</> when the whaituaId is not found', () => {
-    const result = defaultFlowLimitsAndSites('this-id-does-not-exist');
+    const result = defaultFlowLimitsAndSites(0);
     expect(result).toEqual(<>None</>);
   });
 });

--- a/packages/PlanLimitsUI/src/pages/Limits/defaultFlowLimitAndSite.tsx
+++ b/packages/PlanLimitsUI/src/pages/Limits/defaultFlowLimitAndSite.tsx
@@ -2,35 +2,35 @@ import { ArrowTopRightOnSquareIcon } from '@heroicons/react/24/outline';
 
 const defaultFlowLimitsAndSites = [
   {
-    whaituaId: '1',
+    whaituaId: 1,
     text: 'Refer to Policy K.P1',
     link: 'https://pnrp.gw.govt.nz/assets/Uploads/Chapter-10-Kapiti-Coast-Whaitua-Appeal-version-2023.pdf',
   },
   {
-    whaituaId: '2',
+    whaituaId: 2,
     text: 'Refer to Policy P.P1',
     link: 'https://pnrp.gw.govt.nz/assets/Uploads/Chapter-9-Te-Awarua-o-Porirua-Whaitua-Appeal-version-2023.pdf',
   },
   {
-    whaituaId: '3',
+    whaituaId: 3,
     text: 'Refer to Policy TW.P1',
     link: 'https://pnrp.gw.govt.nz/assets/Uploads/Chapter-8-Wellington-Harbour-and-Hutt-Valley-Whaitua-Appeal-version-2023.pdf',
   },
   {
-    whaituaId: '4',
+    whaituaId: 4,
     text: 'Refer to Policy R.P1',
     link: 'https://pnrp.gw.govt.nz/assets/Uploads/Chapter-7-Ruamahanga-Whaitua-Appeal-version-2023.pdf',
   },
   {
-    whaituaId: '5',
+    whaituaId: 5,
     text: 'Refer to Policy WC.P1',
     link: 'https://pnrp.gw.govt.nz/assets/Uploads/Chapter-11-Wairarapa-Coast-Whaitua-Appeal-version-2023.pdf',
   },
 ];
 
-export default function defaultFlowLimit(whaituaId: number | string) {
+export default function defaultFlowLimit(whaituaId: number) {
   const limit = defaultFlowLimitsAndSites.find(
-    (l) => l.whaituaId === whaituaId.toString()
+    (l) => l.whaituaId === whaituaId
   );
 
   if (!limit) return <>None</>;

--- a/packages/PlanLimitsUI/src/pages/Limits/map.tsx
+++ b/packages/PlanLimitsUI/src/pages/Limits/map.tsx
@@ -287,7 +287,11 @@ export default function LimitsMap({
           <Layer
             id="minimumFlowLimitBoundaries-highlight"
             type="fill"
-            filter={['==', ['id'], appState.minimumFlowLimitId]}
+            filter={[
+              '==',
+              ['id'],
+              appState.flowLimitBoundary && appState.flowLimitBoundary.id,
+            ]}
             paint={{
               'fill-outline-color': '#484896',
               'fill-color': '#6e599f',
@@ -315,7 +319,11 @@ export default function LimitsMap({
           paint={{
             'icon-opacity': [
               'case',
-              ['==', ['id'], appState.flowRestrictionsManagementSiteId],
+              [
+                '==',
+                ['id'],
+                appState.flowLimitBoundary && appState.flowLimitBoundary.siteId,
+              ],
               1,
               0.5,
             ],

--- a/packages/PlanLimitsUI/src/pages/Limits/map.tsx
+++ b/packages/PlanLimitsUI/src/pages/Limits/map.tsx
@@ -172,7 +172,7 @@ export default function LimitsMap({
         />
         <Layer
           id="whaitua-highlight"
-          filter={['==', ['id'], appState.whaituaId]}
+          filter={['==', ['id'], appState.whaitua && appState.whaitua.id]}
           type="fill"
           paint={{
             'fill-outline-color': '#484896',

--- a/packages/PlanLimitsUI/src/pages/Limits/sidebar.tsx
+++ b/packages/PlanLimitsUI/src/pages/Limits/sidebar.tsx
@@ -122,16 +122,20 @@ export default function Sidebar({
           <LimitsListItem
             title={'Flow Management Site'}
             text={
-              appState.flowRestrictionsManagementSiteName
-                ? appState.flowRestrictionsManagementSiteName
+              appState.flowLimitBoundary
+                ? appState.flowLimitBoundary.name
+                : appState.whaitua
+                ? appState.whaitua.defaultFlowLimitAndSite
                 : 'None'
             }
           />
           <LimitsListItem
             title={'Minimum Flow or Restriction Flow'}
             text={
-              appState.flowRestrictionsLevel
-                ? appState.flowRestrictionsLevel
+              appState.flowLimitBoundary
+                ? appState.flowLimitBoundary.flowRestriction
+                : appState.whaitua
+                ? appState.whaitua.defaultFlowLimitAndSite
                 : 'None'
             }
           />

--- a/packages/PlanLimitsUI/src/pages/Limits/sidebar.tsx
+++ b/packages/PlanLimitsUI/src/pages/Limits/sidebar.tsx
@@ -87,7 +87,7 @@ export default function Sidebar({
         <dl className="mb-6">
           <LimitsListItem
             title="Whaitua"
-            text={appState.whaitua ? appState.whaitua : 'None'}
+            text={appState.whaitua?.name ?? 'None'}
           />
           {['Surface', 'Combined'].includes(waterTakeFilter) && (
             <>

--- a/packages/PlanLimitsUI/src/pages/Limits/useAppState.ts
+++ b/packages/PlanLimitsUI/src/pages/Limits/useAppState.ts
@@ -4,8 +4,6 @@ import formatWaterQuantity from './formatWaterQuantity';
 import defaultFlowLimitAndSite from './defaultFlowLimitAndSite';
 
 export type AppState = {
-  council?: string | null;
-
   whaitua: null | {
     id: number;
     name: string;
@@ -38,7 +36,6 @@ export function useAppState(): [
   (result: mapboxgl.MapboxGeoJSONFeature[]) => void
 ] {
   const [appState, setAppState] = useState<AppState>({
-    council: null,
     whaitua: null,
     surfaceWaterMgmtUnitId: 'NONE',
     surfaceWaterMgmtUnitDescription: null,
@@ -52,8 +49,6 @@ export function useAppState(): [
   });
 
   const setAppStateFromResult = (result: mapboxgl.MapboxGeoJSONFeature[]) => {
-    const council = findFeature(result, 'councils', 'name');
-
     let whaitua = null;
     const selectedWhaitua = result.find((feat) => feat.layer.id === 'whaitua');
     if (selectedWhaitua) {
@@ -223,7 +218,6 @@ export function useAppState(): [
 
     setAppState({
       ...appState,
-      council,
       whaitua,
 
       // SW

--- a/packages/PlanLimitsUI/src/pages/Limits/useAppState.ts
+++ b/packages/PlanLimitsUI/src/pages/Limits/useAppState.ts
@@ -20,11 +20,11 @@ export type AppState = {
   surfaceWaterMgmtSubUnitAllocated?: string;
   surfaceWaterMgmtSubUnitAllocatedPercentage?: number;
   swLimit?: SWLimit;
-  site?: string | null;
   minimumFlowLimitId: string | null;
   flowRestrictionsManagementSiteId?: string | null;
   flowRestrictionsLevel?: string | JSX.Element | null;
   flowRestrictionsManagementSiteName?: string | JSX.Element | null;
+
   gwLimits?: GWLimit[];
   groundWaterZones: Array<number>;
   groundWaterZoneName?: string;
@@ -42,7 +42,6 @@ export function useAppState(): [
     surfaceWaterMgmtUnitDescription: null,
     surfaceWaterMgmtSubUnitId: 'NONE',
     surfaceWaterMgmtSubUnitDescription: null,
-    site: null,
     minimumFlowLimitId: 'NONE',
     flowRestrictionsManagementSiteId: 'NONE',
     flowRestrictionsLevel: null,
@@ -185,8 +184,6 @@ export function useAppState(): [
     );
 
     // Flow management
-    const site = findFeature(result, 'flowSites', 'Name');
-
     const minimumFlowLimitId =
       findFeatureId(result, 'minimumFlowLimitBoundaries') || 'NONE';
 
@@ -239,7 +236,6 @@ export function useAppState(): [
       groundWaterZones,
       gwLimits,
       // Flow
-      site,
       minimumFlowLimitId,
       flowRestrictionsLevel,
       flowRestrictionsManagementSiteName,


### PR DESCRIPTION
This starts to clean up app state by wrapping related data into objects / types, rationalising the use of undefined / null / 'none', and removing unused state.

I started to take [the next step of doing the same for SW and GW limits](https://github.com/Greater-Wellington-Regional-Council/Environmental-Outcomes-Platform/compare/refactor-app-state...refactor-limits-state), and realised that we'd probably be better off with a more generalised approach to mapping data returned by API to client state, rather than bespoke code for each object. This is a wider change that would be handled better independently, so pausing that for now, and raising this PR to _bank_ the changes so far.