### PR TITLE
Seperate the Build and Deploy Actions

### DIFF
--- a/.github/workflows/docs-site-build.yml
+++ b/.github/workflows/docs-site-build.yml
@@ -1,21 +1,13 @@
-name: Docs Site Deploy
+name: Docs Site Build
 
 on:
   push:
     branches:
-      - main
+      - *
+      - !main
     paths:
         - .github/workflows/docs-site-deploy.yml
         - docs-site/**
-
-permissions:
-  contents: read
-  pages: write
-  id-token: write
-
-concurrency:
-  group: "pages"
-  cancel-in-progress: true
 
 jobs:
   build:
@@ -23,11 +15,6 @@ jobs:
     defaults:
       run:
         working-directory: ./docs-site
-
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
-
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -43,7 +30,3 @@ jobs:
         uses: actions/upload-pages-artifact@v1
         with:
           path: ./docs-site/public
-
-      - name: Deploy to GitHub Pages
-        id: deployment
-        uses: actions/deploy-pages@v1


### PR DESCRIPTION
This PR adds a new GitHub action that just builds the docs site as part of CI and does not depend on the "pages" deploy environment.

This is to have it separate from the "Deploy" job which only runs on `main` does depend on the "pages" environment, and thus limits concurrency 

