### PR TITLE
Clean up handling of map state and events

### DIFF
--- a/packages/PlanLimitsUI/src/pages/Limits/index.spec.tsx
+++ b/packages/PlanLimitsUI/src/pages/Limits/index.spec.tsx
@@ -23,6 +23,7 @@ describe('loader', () => {
         longitude: 175.166,
         zoom: 8,
       },
+      pinnedLocation: null,
     });
   });
 

--- a/packages/PlanLimitsUI/src/pages/Limits/index.tsx
+++ b/packages/PlanLimitsUI/src/pages/Limits/index.tsx
@@ -37,7 +37,7 @@ export const loader: LoaderFunction = ({ params, request }) => {
   return parsedLocation
     ? {
         locationString: parsedLocation,
-        pinnedLocation: parsedPinnedLocation || undefined,
+        pinnedLocation: parsedPinnedLocation || null,
       }
     : redirect(`/limits/${createLocationString(defaultViewLocation)}`);
 };
@@ -50,11 +50,11 @@ export default function Limits() {
     pinnedLocation: initialPinnedLocation,
   } = useLoaderData() as {
     locationString: ViewLocation;
-    pinnedLocation?: PinnedLocation;
+    pinnedLocation: PinnedLocation | null;
   };
 
   const [pinnedLocation, setPinnedLocation] = useState(initialPinnedLocation);
-  const [viewLocation, setCurrentViewLocation] = useState(initialViewLocation);
+  const [viewLocation, setViewLocation] = useState(initialViewLocation);
 
   const debouncedValue = useDebounce<ViewLocation>(viewLocation, 500);
   useEffect(() => {
@@ -66,7 +66,7 @@ export default function Limits() {
     } else {
       navigate(`/limits/${createLocationString(debouncedValue)}`);
     }
-  }, [debouncedValue, pinnedLocation]);
+  }, [debouncedValue, pinnedLocation, navigate]);
 
   const geoJsonQueries = useGeoJsonQueries();
 
@@ -88,9 +88,11 @@ export default function Limits() {
   });
 
   const setViewState = (value: ViewState) => {
-    setCurrentViewLocation(value);
+    setViewLocation(value);
     storeViewState(value);
   };
+
+  const geoJsonDataLoaded = geoJsonQueries.every((query) => query.data);
 
   return (
     <div className="flex">
@@ -100,10 +102,11 @@ export default function Limits() {
           setAppState={setAppState}
           viewState={viewState}
           setViewState={setViewState}
-          initialPinnedLocation={initialPinnedLocation}
-          setCurrentPinnedLocation={setPinnedLocation}
+          pinnedLocation={pinnedLocation}
+          setPinnedLocation={setPinnedLocation}
           waterTakeFilter={waterTakeFilter}
           queries={geoJsonQueries}
+          geoJsonDataLoaded={geoJsonDataLoaded}
         />
       </main>
       <aside className="w-[36rem] h-screen overflow-y-scroll border-l border-gray-200">

--- a/packages/PlanLimitsUI/src/pages/Limits/map.tsx
+++ b/packages/PlanLimitsUI/src/pages/Limits/map.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback } from 'react';
+import { useState, useEffect, useRef, type SetStateAction } from 'react';
 import mapboxgl from 'mapbox-gl';
 import maplibregl from 'maplibre-gl';
 import 'maplibre-gl/dist/maplibre-gl.css';
@@ -10,6 +10,9 @@ import Map, {
   ScaleControl,
   type MapRef,
   type ViewState,
+  type ViewStateChangeEvent,
+  type MapboxEvent,
+  type MapLayerMouseEvent,
 } from 'react-map-gl';
 import { GeoJsonQueries } from '../../api';
 import LayerControl from '../../components/map/LayerControl';
@@ -20,10 +23,22 @@ import type { AppState } from './useAppState';
 import type { WaterTakeFilter } from './index';
 import flowMarkerImage from '../../images/marker_flow.svg';
 
-const publicLinzApiKey = import.meta.env.VITE_LINZ_API_KEY;
+const LINZ_API_KEY = import.meta.env.VITE_LINZ_API_KEY;
 const EMPTY_GEO_JSON_DATA = {
   type: 'FeatureCollection' as const,
   features: [],
+};
+
+type Props = {
+  appState: AppState;
+  setAppState: (result: mapboxgl.MapboxGeoJSONFeature[]) => void;
+  viewState: ViewState;
+  setViewState: (value: ViewState) => void;
+  pinnedLocation: PinnedLocation | null;
+  setPinnedLocation: (prevValue: SetStateAction<PinnedLocation | null>) => void;
+  waterTakeFilter: WaterTakeFilter;
+  queries: GeoJsonQueries;
+  geoJsonDataLoaded: boolean;
 };
 
 export default function LimitsMap({
@@ -31,55 +46,16 @@ export default function LimitsMap({
   setAppState,
   viewState,
   setViewState,
-  initialPinnedLocation,
-  setCurrentPinnedLocation,
+  pinnedLocation,
+  setPinnedLocation,
   waterTakeFilter,
   queries,
-}: {
-  appState: AppState;
-  setAppState: (result: mapboxgl.MapboxGeoJSONFeature[]) => void;
-  viewState: ViewState;
-  setViewState: (value: ViewState) => void;
-  initialPinnedLocation?: PinnedLocation;
-  setCurrentPinnedLocation: (value?: PinnedLocation) => void;
-  waterTakeFilter: WaterTakeFilter;
-  queries: GeoJsonQueries;
-}) {
-  const [mapRenderCount, setMapRenderCount] = useState(0);
-  const [showImagery, setShowImagery] = useState(false);
-
-  const [pinnedLocation, storePinnedLocation] = useState(initialPinnedLocation);
-
-  const [highlightLocation, setHighlightLocation] = useState<
-    PinnedLocation | undefined
-  >(initialPinnedLocation);
-
+  geoJsonDataLoaded,
+}: Props) {
+  const mapRef = useRef<MapRef | null>(null);
+  const [mapLoaded, setMapLoaded] = useState(false);
   const [flowMarkerImageAdded, setFlowMarkerImageAdded] = useState(false);
-  const [flowMarkerImageLoading, setFlowMarkerImageLoading] = useState(false);
-
-  const changesCallback = useCallback(
-    (map: MapRef | null) => {
-      if (highlightLocation && map) {
-        const result = map.queryRenderedFeatures(
-          map.project([highlightLocation.longitude, highlightLocation.latitude])
-        );
-        setAppState(result);
-      }
-
-      // TODO: Move this out of main rendering callback and extract to hook/HOC
-      if (map && !map.hasImage('marker_flow') && !flowMarkerImageLoading) {
-        setFlowMarkerImageLoading(true);
-        const img = new Image(20, 20);
-        img.onload = () => {
-          map.addImage('marker_flow', img);
-          setFlowMarkerImageAdded(true);
-        };
-        img.src = flowMarkerImage;
-      }
-    },
-    [highlightLocation, mapRenderCount, waterTakeFilter]
-  );
-
+  const [showImagery, setShowImagery] = useState(false);
   const [
     councilsGeoJson,
     whaituaGeoJson,
@@ -90,42 +66,67 @@ export default function LimitsMap({
     groundwaterZoneBoundariesGeoJson,
   ] = queries;
 
+  useEffect(() => {
+    if (mapLoaded && mapRef.current && geoJsonDataLoaded && pinnedLocation) {
+      const activeFeatures = mapRef.current.queryRenderedFeatures(
+        mapRef.current.project([
+          pinnedLocation.longitude,
+          pinnedLocation.latitude,
+        ])
+      );
+      setAppState(activeFeatures);
+    }
+  }, [mapLoaded, geoJsonDataLoaded, pinnedLocation, setAppState]);
+
+  const handleLoad = (evt: MapboxEvent) => {
+    setMapLoaded(true);
+
+    const img = new Image(20, 20);
+    img.onload = () => {
+      evt.target.addImage('marker_flow', img);
+      setFlowMarkerImageAdded(true);
+    };
+    img.src = flowMarkerImage;
+  };
+
+  const handleMove = (evt: ViewStateChangeEvent) => {
+    setViewState(evt.viewState);
+  };
+
+  const handleMouseMove = (evt: MapLayerMouseEvent) => {
+    if (pinnedLocation) return;
+
+    const result = evt.target.queryRenderedFeatures(evt.point);
+    setAppState(result);
+  };
+
+  const handleClick = (evt: MapLayerMouseEvent) => {
+    setPinnedLocation((prevValue) =>
+      prevValue
+        ? null
+        : {
+            latitude: evt.lngLat.lat,
+            longitude: evt.lngLat.lng,
+          }
+    );
+  };
+
   return (
     <Map
-      ref={changesCallback}
+      ref={mapRef}
       reuseMaps={true}
       mapLib={maplibregl}
       style={{ width: '100%', height: '100vh' }}
-      mapStyle={`https://basemaps.linz.govt.nz/v1/tiles/topographic/EPSG:4326/style/topographic.json?api=${publicLinzApiKey}`}
+      mapStyle={`https://basemaps.linz.govt.nz/v1/tiles/topographic/EPSG:4326/style/topographic.json?api=${LINZ_API_KEY}`}
       minZoom={5}
       maxBounds={[
         [160, -60],
         [-160, -20],
       ]}
-      onMove={(evt) => setViewState(evt.viewState)}
-      onMouseMove={(evt) => {
-        if (!pinnedLocation) {
-          setHighlightLocation({
-            latitude: evt.lngLat.lat,
-            longitude: evt.lngLat.lng,
-          });
-        }
-      }}
-      onClick={(evt) => {
-        const newPinnedLocation = pinnedLocation
-          ? undefined
-          : {
-              latitude: evt.lngLat.lat,
-              longitude: evt.lngLat.lng,
-            };
-        setCurrentPinnedLocation(newPinnedLocation);
-        storePinnedLocation(newPinnedLocation);
-        setHighlightLocation({
-          latitude: evt.lngLat.lat,
-          longitude: evt.lngLat.lng,
-        });
-      }}
-      onRender={() => setMapRenderCount(mapRenderCount + 1)}
+      onMove={handleMove}
+      onMouseMove={handleMouseMove}
+      onClick={handleClick}
+      onLoad={handleLoad}
       {...viewState}
     >
       <NavigationControl position="top-left" visualizePitch={true} />
@@ -342,7 +343,7 @@ export default function LimitsMap({
         <Source
           type={'raster'}
           tiles={[
-            `https://basemaps.linz.govt.nz/v1/tiles/aerial/WebMercatorQuad/{z}/{x}/{y}.webp?api=${publicLinzApiKey}`,
+            `https://basemaps.linz.govt.nz/v1/tiles/aerial/WebMercatorQuad/{z}/{x}/{y}.webp?api=${LINZ_API_KEY}`,
           ]}
         >
           <Layer beforeId="councils" type={'raster'} />

--- a/packages/PlanLimitsUI/src/pages/Limits/map.tsx
+++ b/packages/PlanLimitsUI/src/pages/Limits/map.tsx
@@ -35,7 +35,9 @@ type Props = {
   viewState: ViewState;
   setViewState: (value: ViewState) => void;
   pinnedLocation: PinnedLocation | null;
-  setPinnedLocation: (prevValue: SetStateAction<PinnedLocation | null>) => void;
+  setPinnedLocation: (
+    updateFn: (prevValue: PinnedLocation | null) => PinnedLocation | null
+  ) => void;
   waterTakeFilter: WaterTakeFilter;
   queries: GeoJsonQueries;
   geoJsonDataLoaded: boolean;

--- a/packages/PlanLimitsUI/src/pages/Limits/useAppState.ts
+++ b/packages/PlanLimitsUI/src/pages/Limits/useAppState.ts
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, useCallback } from 'react';
 import mapboxgl from 'mapbox-gl';
 import formatWaterQuantity from './formatWaterQuantity';
 import defaultFlowLimitAndSite from './defaultFlowLimitAndSite';
@@ -82,95 +82,77 @@ export function useAppState(): [
     groundWaterZones: [],
   });
 
-  const setAppStateFromResult = (
-    activeFeatures: mapboxgl.MapboxGeoJSONFeature[]
-  ) => {
-    const whaitua = setWhaitua(activeFeatures);
-    const flowLimitBoundary = setFlowLimitBoundary(activeFeatures);
+  const setAppStateFromResult = useCallback(
+    (activeFeatures: mapboxgl.MapboxGeoJSONFeature[]) => {
+      const whaitua = setWhaitua(activeFeatures);
+      const flowLimitBoundary = setFlowLimitBoundary(activeFeatures);
 
-    const result = activeFeatures;
-    // Surface water MgmtUnit
-    const surfaceWaterMgmtUnitId =
-      findFeatureId(result, 'surfaceWaterMgmtUnits') || null;
-    const surfaceWaterMgmtUnitDescription = findFeature(
-      result,
-      'surfaceWaterMgmtUnits',
-      'name'
-    );
-    const surfaceWaterMgmtUnitLimitAmount = findFeature(
-      result,
-      'surfaceWaterMgmtUnits',
-      'allocation_amount'
-    );
-    const surfaceWaterMgmtUnitLimit = surfaceWaterMgmtUnitLimitAmount
-      ? formatWaterQuantity(
-          Number(surfaceWaterMgmtUnitLimitAmount),
-          findFeature(
-            result,
-            'surfaceWaterMgmtUnits',
-            'allocation_amount_unit'
-          ) as string
-        )
-      : undefined;
-
-    const surfaceWaterMgmtUnitAllocatedAmount = findFeature(
-      result,
-      'surfaceWaterMgmtUnits',
-      'allocated_amount'
-    );
-    const surfaceWaterMgmtUnitAllocated = surfaceWaterMgmtUnitAllocatedAmount
-      ? formatWaterQuantity(
-          Math.round(Number(surfaceWaterMgmtUnitAllocatedAmount)),
-          findFeature(
-            result,
-            'surfaceWaterMgmtUnits',
-            'allocation_amount_unit'
-          ) as string
-        )
-      : undefined;
-
-    const surfaceWaterMgmtUnitAllocatedPercentage =
-      surfaceWaterMgmtUnitLimitAmount && surfaceWaterMgmtUnitAllocatedAmount
-        ? Math.round(
-            (Number(surfaceWaterMgmtUnitAllocatedAmount) /
-              Number(surfaceWaterMgmtUnitLimitAmount)) *
-              100
+      const result = activeFeatures;
+      // Surface water MgmtUnit
+      const surfaceWaterMgmtUnitId =
+        findFeatureId(result, 'surfaceWaterMgmtUnits') || null;
+      const surfaceWaterMgmtUnitDescription = findFeature(
+        result,
+        'surfaceWaterMgmtUnits',
+        'name'
+      );
+      const surfaceWaterMgmtUnitLimitAmount = findFeature(
+        result,
+        'surfaceWaterMgmtUnits',
+        'allocation_amount'
+      );
+      const surfaceWaterMgmtUnitLimit = surfaceWaterMgmtUnitLimitAmount
+        ? formatWaterQuantity(
+            Number(surfaceWaterMgmtUnitLimitAmount),
+            findFeature(
+              result,
+              'surfaceWaterMgmtUnits',
+              'allocation_amount_unit'
+            ) as string
           )
         : undefined;
 
-    // Surface water MgmtSubUnit
-    const surfaceWaterMgmtSubUnitId =
-      findFeatureId(result, 'surfaceWaterMgmtSubUnits') || null;
-    const surfaceWaterMgmtSubUnitDescription = findFeature(
-      result,
-      'surfaceWaterMgmtSubUnits',
-      'name'
-    );
-    const surfaceWaterMgmtSubUnitLimitAmount = findFeature(
-      result,
-      'surfaceWaterMgmtSubUnits',
-      'allocation_amount'
-    );
-    const surfaceWaterMgmtSubUnitLimit = surfaceWaterMgmtSubUnitLimitAmount
-      ? formatWaterQuantity(
-          Number(surfaceWaterMgmtSubUnitLimitAmount),
-          findFeature(
-            result,
-            'surfaceWaterMgmtSubUnits',
-            'allocation_amount_unit'
-          ) as string
-        )
-      : undefined;
-
-    const surfaceWaterMgmtSubUnitAllocatedAmount = findFeature(
-      result,
-      'surfaceWaterMgmtSubUnits',
-      'allocated_amount'
-    );
-    const surfaceWaterMgmtSubUnitAllocated =
-      surfaceWaterMgmtSubUnitAllocatedAmount
+      const surfaceWaterMgmtUnitAllocatedAmount = findFeature(
+        result,
+        'surfaceWaterMgmtUnits',
+        'allocated_amount'
+      );
+      const surfaceWaterMgmtUnitAllocated = surfaceWaterMgmtUnitAllocatedAmount
         ? formatWaterQuantity(
-            Math.round(Number(surfaceWaterMgmtSubUnitAllocatedAmount)),
+            Math.round(Number(surfaceWaterMgmtUnitAllocatedAmount)),
+            findFeature(
+              result,
+              'surfaceWaterMgmtUnits',
+              'allocation_amount_unit'
+            ) as string
+          )
+        : undefined;
+
+      const surfaceWaterMgmtUnitAllocatedPercentage =
+        surfaceWaterMgmtUnitLimitAmount && surfaceWaterMgmtUnitAllocatedAmount
+          ? Math.round(
+              (Number(surfaceWaterMgmtUnitAllocatedAmount) /
+                Number(surfaceWaterMgmtUnitLimitAmount)) *
+                100
+            )
+          : undefined;
+
+      // Surface water MgmtSubUnit
+      const surfaceWaterMgmtSubUnitId =
+        findFeatureId(result, 'surfaceWaterMgmtSubUnits') || null;
+      const surfaceWaterMgmtSubUnitDescription = findFeature(
+        result,
+        'surfaceWaterMgmtSubUnits',
+        'name'
+      );
+      const surfaceWaterMgmtSubUnitLimitAmount = findFeature(
+        result,
+        'surfaceWaterMgmtSubUnits',
+        'allocation_amount'
+      );
+      const surfaceWaterMgmtSubUnitLimit = surfaceWaterMgmtSubUnitLimitAmount
+        ? formatWaterQuantity(
+            Number(surfaceWaterMgmtSubUnitLimitAmount),
             findFeature(
               result,
               'surfaceWaterMgmtSubUnits',
@@ -179,69 +161,89 @@ export function useAppState(): [
           )
         : undefined;
 
-    const surfaceWaterMgmtSubUnitAllocatedPercentage =
-      surfaceWaterMgmtSubUnitLimitAmount &&
-      surfaceWaterMgmtSubUnitAllocatedAmount
-        ? Math.round(
-            (Number(surfaceWaterMgmtSubUnitAllocatedAmount) /
-              Number(surfaceWaterMgmtSubUnitLimitAmount)) *
-              100
-          )
-        : undefined;
+      const surfaceWaterMgmtSubUnitAllocatedAmount = findFeature(
+        result,
+        'surfaceWaterMgmtSubUnits',
+        'allocated_amount'
+      );
+      const surfaceWaterMgmtSubUnitAllocated =
+        surfaceWaterMgmtSubUnitAllocatedAmount
+          ? formatWaterQuantity(
+              Math.round(Number(surfaceWaterMgmtSubUnitAllocatedAmount)),
+              findFeature(
+                result,
+                'surfaceWaterMgmtSubUnits',
+                'allocation_amount_unit'
+              ) as string
+            )
+          : undefined;
 
-    const swLimit = getSwLimit(
-      whaitua?.id,
-      surfaceWaterMgmtUnitLimit,
-      surfaceWaterMgmtSubUnitLimit
-    );
+      const surfaceWaterMgmtSubUnitAllocatedPercentage =
+        surfaceWaterMgmtSubUnitLimitAmount &&
+        surfaceWaterMgmtSubUnitAllocatedAmount
+          ? Math.round(
+              (Number(surfaceWaterMgmtSubUnitAllocatedAmount) /
+                Number(surfaceWaterMgmtSubUnitLimitAmount)) *
+                100
+            )
+          : undefined;
 
-    // Groundwater
-    const groundWaterZonesData = result
-      .filter((value) => value.layer.id === 'groundWater')
-      .sort((a, b) => {
-        // This specific sorting is ok because the set of values we have for Depths can always be sorted by the first character currently
-        const alphabet = '0123456789>';
-        const first = a.properties?.depth.charAt(0);
-        const second = b.properties?.depth.charAt(0);
-        return alphabet.indexOf(first) - alphabet.indexOf(second);
+      const swLimit = getSwLimit(
+        whaitua?.id,
+        surfaceWaterMgmtUnitLimit,
+        surfaceWaterMgmtSubUnitLimit
+      );
+
+      // Groundwater
+      const groundWaterZonesData = result
+        .filter((value) => value.layer.id === 'groundWater')
+        .sort((a, b) => {
+          // This specific sorting is ok because the set of values we have for Depths can always be sorted by the first character currently
+          const alphabet = '0123456789>';
+          const first = a.properties?.depth.charAt(0);
+          const second = b.properties?.depth.charAt(0);
+          return alphabet.indexOf(first) - alphabet.indexOf(second);
+        });
+
+      const groundWaterZones = groundWaterZonesData.map(
+        (item) => item.id as number
+      );
+      const groundWaterZoneName = [
+        // Contructing then destructuring from a Set leaves us with unique values
+        ...new Set(
+          groundWaterZonesData.map((item) => item.properties!['name'])
+        ),
+      ].join(', ');
+
+      const gwLimits = getGwLimits(
+        groundWaterZonesData as mapboxgl.MapboxGeoJSONFeature[]
+      );
+
+      setAppState({
+        whaitua,
+        flowLimitBoundary,
+
+        // SW
+        surfaceWaterMgmtUnitId,
+        surfaceWaterMgmtUnitDescription,
+        surfaceWaterMgmtUnitLimit,
+        surfaceWaterMgmtUnitAllocated,
+        surfaceWaterMgmtUnitAllocatedPercentage,
+        surfaceWaterMgmtSubUnitId,
+        surfaceWaterMgmtSubUnitDescription,
+        surfaceWaterMgmtSubUnitLimit,
+        surfaceWaterMgmtSubUnitAllocated,
+        surfaceWaterMgmtSubUnitAllocatedPercentage,
+
+        swLimit,
+        // GW
+        groundWaterZoneName,
+        groundWaterZones,
+        gwLimits,
       });
-
-    const groundWaterZones = groundWaterZonesData.map(
-      (item) => item.id as number
-    );
-    const groundWaterZoneName = [
-      // Contructing then destructuring from a Set leaves us with unique values
-      ...new Set(groundWaterZonesData.map((item) => item.properties!['name'])),
-    ].join(', ');
-
-    const gwLimits = getGwLimits(
-      groundWaterZonesData as mapboxgl.MapboxGeoJSONFeature[]
-    );
-
-    setAppState({
-      ...appState,
-      whaitua,
-      flowLimitBoundary,
-
-      // SW
-      surfaceWaterMgmtUnitId,
-      surfaceWaterMgmtUnitDescription,
-      surfaceWaterMgmtUnitLimit,
-      surfaceWaterMgmtUnitAllocated,
-      surfaceWaterMgmtUnitAllocatedPercentage,
-      surfaceWaterMgmtSubUnitId,
-      surfaceWaterMgmtSubUnitDescription,
-      surfaceWaterMgmtSubUnitLimit,
-      surfaceWaterMgmtSubUnitAllocated,
-      surfaceWaterMgmtSubUnitAllocatedPercentage,
-
-      swLimit,
-      // GW
-      groundWaterZoneName,
-      groundWaterZones,
-      gwLimits,
-    });
-  };
+    },
+    [setAppState]
+  );
 
   return [appState, setAppStateFromResult];
 }


### PR DESCRIPTION
Changes:
- Call `setAppState` based on a mouseMove event, rather than previous combination of a callback ref and the render event
- Ensure initial call to `setAppState` based on pinnedLocation is only done once map and api data is loaded. (I think there was a latent bug in the code where `setAppState` would be called with an incomplete list of active map features due to a race condition between the loading of API data and other initialisation code; and this was masked by the use of the render event to trigger `setAppState`.
- Remove duplicate `pinnedLocation` and `highlightLocation` state nested in the map component
- Use null (rather than undefined) to signal the absence of a pinnedLocation
