### PR TITLE
Docs: Add "Current status" and "How to Contribute" content

### DIFF
--- a/docs-site/src/components/header.tsx
+++ b/docs-site/src/components/header.tsx
@@ -10,7 +10,7 @@ export default () => (
       <a
         className="group"
         aria-label="GitHub"
-        href="https://greater-wellington-regional-council.github.io/Environmental-Outcomes-Platform"
+        href="https://github.com/Greater-Wellington-Regional-Council/Environmental-Outcomes-Platform"
       >
         <svg
           aria-hidden="true"

--- a/docs-site/src/markdown-pages/contributing/how-to.md
+++ b/docs-site/src/markdown-pages/contributing/how-to.md
@@ -4,88 +4,12 @@ section: Contributing
 title: How to contribute
 ---
 
-Placeholder - Contribution Guide
+EOP is intended to be a sector-wide initiative with contributions from many councils.
 
----
+We're [currently working](/work-in-progress/current-status) on integrating data from other councils into the [Plan Limits Viewer](/work-in-progress/plan-limits). If this is something you are interested in, please get in touch.
 
-## Quis vel iste dicta
+We're also working towards technical contributions from other councils to the platform. Once formed, the [Technical Working Group](/#technical-working-group) will be esablishing guidelines for this, including an RFC process for substantial changes.
 
-Sit commodi iste iure molestias qui amet voluptatem sed quaerat. Nostrum aut
-pariatur. Sint ipsa praesentium dolor error cumque velit tenetur.
+In the meantime, if you're interested in following along with technical details, check out the [EOP](https://github.com/Greater-Wellington-Regional-Council/Environmental-Outcomes-Platform) and [EOP Infrastructure](https://github.com/Greater-Wellington-Regional-Council/Environmental-Outcomes-Platform-Infrastructure) GitHub repos.
 
-### Et pariatur ab quas
 
-Sit commodi iste iure molestias qui amet voluptatem sed quaerat. Nostrum aut
-pariatur. Sint ipsa praesentium dolor error cumque velit tenetur quaerat
-exercitationem. Consequatur et cum atque mollitia qui quia necessitatibus.
-
-Possimus saepe veritatis sint nobis et quam eos. Architecto consequatur odit
-perferendis fuga eveniet possimus rerum cumque. Ea deleniti voluptatum deserunt
-voluptatibus ut non iste. Provident nam asperiores vel laboriosam omnis ducimus
-enim nesciunt quaerat. Minus tempora cupiditate est quod.
-
-### Natus aspernatur iste
-
-Sit commodi iste iure molestias qui amet voluptatem sed quaerat. Nostrum aut
-pariatur. Sint ipsa praesentium dolor error cumque velit tenetur quaerat
-exercitationem. Consequatur et cum atque mollitia qui quia necessitatibus.
-
-Voluptas beatae omnis omnis voluptas. Cum architecto ab sit ad eaque quas quia
-distinctio. Molestiae aperiam qui quis deleniti soluta quia qui. Dolores nostrum
-blanditiis libero optio id. Mollitia ad et asperiores quas saepe alias.
-
----
-
-## Quos porro ut molestiae
-
-Sit commodi iste iure molestias qui amet voluptatem sed quaerat. Nostrum aut
-pariatur. Sint ipsa praesentium dolor error cumque velit tenetur.
-
-### Voluptatem quas possimus
-
-Sit commodi iste iure molestias qui amet voluptatem sed quaerat. Nostrum aut
-pariatur. Sint ipsa praesentium dolor error cumque velit tenetur quaerat
-exercitationem. Consequatur et cum atque mollitia qui quia necessitatibus.
-
-Possimus saepe veritatis sint nobis et quam eos. Architecto consequatur odit
-perferendis fuga eveniet possimus rerum cumque. Ea deleniti voluptatum deserunt
-voluptatibus ut non iste. Provident nam asperiores vel laboriosam omnis ducimus
-enim nesciunt quaerat. Minus tempora cupiditate est quod.
-
-### Id vitae minima
-
-Sit commodi iste iure molestias qui amet voluptatem sed quaerat. Nostrum aut
-pariatur. Sint ipsa praesentium dolor error cumque velit tenetur quaerat
-exercitationem. Consequatur et cum atque mollitia qui quia necessitatibus.
-
-Voluptas beatae omnis omnis voluptas. Cum architecto ab sit ad eaque quas quia
-distinctio. Molestiae aperiam qui quis deleniti soluta quia qui. Dolores nostrum
-blanditiis libero optio id. Mollitia ad et asperiores quas saepe alias.
-
----
-
-## Vitae laborum maiores
-
-Sit commodi iste iure molestias qui amet voluptatem sed quaerat. Nostrum aut
-pariatur. Sint ipsa praesentium dolor error cumque velit tenetur.
-
-### Corporis exercitationem
-
-Sit commodi iste iure molestias qui amet voluptatem sed quaerat. Nostrum aut
-pariatur. Sint ipsa praesentium dolor error cumque velit tenetur quaerat
-exercitationem. Consequatur et cum atque mollitia qui quia necessitatibus.
-
-Possimus saepe veritatis sint nobis et quam eos. Architecto consequatur odit
-perferendis fuga eveniet possimus rerum cumque. Ea deleniti voluptatum deserunt
-voluptatibus ut non iste. Provident nam asperiores vel laboriosam omnis ducimus
-enim nesciunt quaerat. Minus tempora cupiditate est quod.
-
-### Reprehenderit magni
-
-Sit commodi iste iure molestias qui amet voluptatem sed quaerat. Nostrum aut
-pariatur. Sint ipsa praesentium dolor error cumque velit tenetur quaerat
-exercitationem. Consequatur et cum atque mollitia qui quia necessitatibus.
-
-Voluptas beatae omnis omnis voluptas. Cum architecto ab sit ad eaque quas quia
-distinctio. Molestiae aperiam qui quis deleniti soluta quia qui. Dolores nostrum
-blanditiis libero optio id. Mollitia ad et asperiores quas saepe alias.

--- a/docs-site/src/markdown-pages/index.md
+++ b/docs-site/src/markdown-pages/index.md
@@ -25,14 +25,14 @@ engineering team.
 
 EOP aims to address these issues by building a solution which focuses on:
 
-_Outcomes_
+<h3 id="outcomes">Outcomes</h3>
 
 The unit of delivery in EOP is an outcome, information provided to a user in a
 way which is appropriate to their needs. For each outcome, the minimum technical
 architecture will be built to deliver that outcome. With future outcomes
 building and evolving, the architecture to support the new outcomes.
 
-_Multi Tenanted_
+### Multi Tenanted
 
 From the ground up EOP is being built to support multiple councils. This will
 enable the effort to deliver an outcome by one council to be delivered to all
@@ -41,7 +41,7 @@ council internal systems with each council providing data to EOP in a
 standardised format. However, for some common systems used in a majority of
 councils, EOP can provide standardised adapters to allow the data to be
 
-_Modern Development Practices_
+### Modern Development Practices
 
 The EOP platform will be developed using modern development and delivery
 practices to reduce the risk of the platform becoming legacy, and help ensure
@@ -61,7 +61,7 @@ Steering Group on the strategic direction of EOP. The second is a Technical
 Working Group which will focus on the technical direction of EOP in terms of
 architecture, collaboration, development practices and technical priorities.
 
-### Steering Group
+<h3 id="steering-group">Steering Group</h3>
 
 The steering group has a Terms of Reference formed which describes the
 responsibilities of the Steering Group as follows:
@@ -85,7 +85,7 @@ responsibilities of the Steering Group as follows:
 - To resolve any dispute or disagreement that is raised through the governance
   structure.
 
-### Technical Working Group
+<h3 id="technical-working-group">Technical Working Group</h3>
 
 A technical group is going to be setup in 2023 led by the EOP Delivery team.
 This will be the forum to share and collaborate on the technical solution across

--- a/docs-site/src/markdown-pages/work-in-progress/current-status.md
+++ b/docs-site/src/markdown-pages/work-in-progress/current-status.md
@@ -1,7 +1,7 @@
 ---
 slug: /work-in-progress/current-status
 section: In Progress
-title: Current Status
+title: Current status
 ---
 
 The EOP initiative is currently being incubated and led by a dedicated delivery team within Greater Wellington. This team consists of a Product Owner and Data and Software Engineers, and is working closely with subject matter experts from Greater Wellington and other councils.

--- a/docs-site/src/markdown-pages/work-in-progress/current-status.md
+++ b/docs-site/src/markdown-pages/work-in-progress/current-status.md
@@ -1,0 +1,19 @@
+---
+slug: /work-in-progress/current-status
+section: In Progress
+title: Current Status
+---
+
+The EOP initiative is currently being incubated and led by a dedicated delivery team within Greater Wellington. This team consists of a Product Owner and Data and Software Engineers, and is working closely with subject matter experts from Greater Wellington and other councils.
+
+The team has been operational since late 2022, and progress to date includes:
+- Design and provisioning of initial cloud infrastructure to support the platform
+- Development of our first [outcome](/#outcomes), a [Plan Limits Viewer](/work-in-progress/plan-limits)
+- Establishment of a [Steering Grouop](/#steering-group)
+
+### What's up next:
+
+The roadmap for the few months includes:
+- Iterating on the Plan Limits Viewer to include consented allocation amounts and usage
+- Integrating data from other councils into the Plan Limits Viewer
+- Establishment of a [Technical Working Group](/#technical-working-group)

--- a/docs-site/src/navigation.ts
+++ b/docs-site/src/navigation.ts
@@ -17,8 +17,9 @@ export default [
   {
     title: 'Work in Progress',
     links: [
-      {title: 'Plan Limits', href: '/work-in-progress/plan-limits'}
-    ]
+      { title: 'Plan Limits', href: '/work-in-progress/plan-limits' },
+      { title: 'Current status', href: '/work-in-progress/current-status' },
+    ],
   },
   {
     title: 'Contributing',


### PR DESCRIPTION
Add a new Current status page, and content to the How to contribute page.

The PR is stacked against the `docs/what_is_eop` branch so it can reference updated content in that page.