### PR TITLE
Include total ruamahanga as an allocation amount.

### DIFF
--- a/packages/Manager/src/main/resources/db/migration-dev/V0019.2__insert_new_test_water_allocation.sql
+++ b/packages/Manager/src/main/resources/db/migration-dev/V0019.2__insert_new_test_water_allocation.sql
@@ -1,0 +1,1 @@
+INSERT INTO water_allocations(area_id, amount, last_updated_ingest_id, created_at, updated_at, received_at) VALUES('RuamahangaTotalSW', 7000, 'dev-import', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP);

--- a/packages/Manager/src/main/resources/db/migration/V0021__update_area_id_in_allocation_amounts.sql
+++ b/packages/Manager/src/main/resources/db/migration/V0021__update_area_id_in_allocation_amounts.sql
@@ -1,0 +1,1 @@
+UPDATE allocation_amounts SET area_id = 'RuamahangaTotalSW' WHERE id = 16;


### PR DESCRIPTION
we had missed this area when we added consented allocation areas on round one.