### PR TITLE
Making deployment steps get skipped when on Github Actions

### DIFF
--- a/.github/workflows/hilltop-crawler.yml
+++ b/.github/workflows/hilltop-crawler.yml
@@ -54,6 +54,7 @@ jobs:
           path: ${{ env.WORKING_DIR }}/build/reports
 
       - name: Configure AWS credentials
+        if: ${{ github.actor != 'dependabot[bot]' }}
         uses: aws-actions/configure-aws-credentials@v1
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
@@ -64,10 +65,12 @@ jobs:
           role-session-name: GitHubActions
 
       - name: Login to Amazon ECR
+        if: ${{ github.actor != 'dependabot[bot]' }}
         id: login-ecr
         uses: aws-actions/amazon-ecr-login@v1
 
       - name: Build and push docker image
+        if: ${{ github.actor != 'dependabot[bot]' }}
         env:
           ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
           ECR_REPOSITORY: eop-hilltop-crawler

--- a/.github/workflows/ingest-api.yml
+++ b/.github/workflows/ingest-api.yml
@@ -54,6 +54,7 @@ jobs:
           path: ${{ env.WORKING_DIR }}/build/reports
 
       - name: Configure AWS credentials
+        if: ${{ github.actor != 'dependabot[bot]' }}      
         uses: aws-actions/configure-aws-credentials@v1
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
@@ -64,10 +65,12 @@ jobs:
           role-session-name: GitHubActions
 
       - name: Login to Amazon ECR
+        if: ${{ github.actor != 'dependabot[bot]' }}      
         id: login-ecr
         uses: aws-actions/amazon-ecr-login@v1
 
       - name: Build and push docker image
+        if: ${{ github.actor != 'dependabot[bot]' }}      
         env:
           ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
           ECR_REPOSITORY: eop-ingest-api

--- a/.github/workflows/manager.yml
+++ b/.github/workflows/manager.yml
@@ -54,6 +54,7 @@ jobs:
           path: ${{ env.WORKING_DIR }}/build/reports
 
       - name: Configure AWS credentials
+        if: ${{ github.actor != 'dependabot[bot]' }}      
         uses: aws-actions/configure-aws-credentials@v1
         with:
             aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
@@ -64,10 +65,12 @@ jobs:
             role-session-name: GitHubActions
 
       - name: Login to Amazon ECR
+        if: ${{ github.actor != 'dependabot[bot]' }}      
         id: login-ecr
         uses: aws-actions/amazon-ecr-login@v1
 
       - name: Build and push docker image
+        if: ${{ github.actor != 'dependabot[bot]' }}      
         env:
           ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
           ECR_REPOSITORY: eop-manager


### PR DESCRIPTION
The Dependabot PRs fail to build because they don't by default have access to the secrets needed for deployment.

Thought best approach is to just not do the deployments because we will never deploy the versions created by these PR's