### PR TITLE
Config ErrorHandlingDeserializer to DLQ unparsable messages

### DIFF
--- a/packages/Manager/src/main/resources/application.yml
+++ b/packages/Manager/src/main/resources/application.yml
@@ -18,10 +18,25 @@ spring:
 
     consumer:
       auto-offset-reset: earliest
-      value-deserializer: org.springframework.kafka.support.serializer.JsonDeserializer
+      key-deserializer: org.springframework.kafka.support.serializer.ErrorHandlingDeserializer
+      value-deserializer: org.springframework.kafka.support.serializer.ErrorHandlingDeserializer
       properties:
         spring.json.value.type.method: nz.govt.eop.messages.KafkaMessageTypes.determineTypeFromTopicName
         spring.json.trusted.packages: nz.govt.eop.*
+        spring.deserializer.key.delegate.class: org.apache.kafka.common.serialization.StringDeserializer
+        spring.deserializer.value.delegate.class: org.springframework.kafka.support.serializer.JsonDeserializer
+
+
+    # These producer settings are used when publishing messages to the DLQ
+    producer:
+      key-serializer: org.apache.kafka.common.serialization.StringSerializer
+      # In the situation that a message was received as invalid JSON and could not be deserialized, it ends up being a ByteArray message that gets published.
+      # the JSON serializer will still serialize the ByteArray as a string, but it will be a string of bytes, not a string of characters.
+      # See WaterAllocationConsumerErrorHandlerTest
+      # Can't figure out a good way to avoid this without writing a custom serializer.
+      value-serializer: org.springframework.kafka.support.serializer.JsonSerializer
+      properties:
+        spring.json.add.type.headers: false
 
     streams:
       properties:
@@ -31,6 +46,8 @@ spring:
           key.serde: org.apache.kafka.common.serialization.Serdes$StringSerde
           value.serde: org.apache.kafka.common.serialization.Serdes$StringSerde
       application-id: nz.govt.eop.consumers.manager
+
+
 management:
   endpoints:
     enabled-by-default: true

--- a/packages/Manager/src/test/resources/application-test.yml
+++ b/packages/Manager/src/test/resources/application-test.yml
@@ -12,13 +12,6 @@ spring:
     user: postgres
     password: password
 
-  kafka:
-    producer:
-      key-serializer: org.apache.kafka.common.serialization.StringSerializer
-      value-serializer: org.springframework.kafka.support.serializer.JsonSerializer
-      properties:
-        spring.json.add.type.headers: false
-
 logging:
   level:
     root: WARN


### PR DESCRIPTION
Main thing here is configuring `org.springframework.kafka.support.serializer.ErrorHandlingDeserializer` which delegates to a real Deserializer and if that fails it does some magic to the message via Headers so the spring consumer code knows to reject it. 

## Notes
There then was a bit of faff because when a message is rejected in this way it has a "value" that is a Byte Array. So the producer a ByteArraySerializer to write it.

But when a message is rejected because the consumer code failed, it still needs to use the JsonSerializer to write it

And there might be a way to do it, but from a bit of time spent didn't quite get it ... and the JsonSerializer already hadnles being passed a ByteArray, it will JSON encode that byte array as a JSON string (see the example in the test)

... The end result being if this occurs the message that ends up in the DLQ isn't super useful to us, but it should have had an error logged and it is for the corner case of getting invalid data into the queue again.