### PR TITLE
Changes for Water Use View

### DIFF
--- a/packages/Manager/src/main/resources/db/migration/V0033__observed_water_use_aggregated_daily_view.sql
+++ b/packages/Manager/src/main/resources/db/migration/V0033__observed_water_use_aggregated_daily_view.sql
@@ -1,0 +1,22 @@
+CREATE OR REPLACE VIEW observed_water_use_aggregated_daily AS
+
+WITH filtered_obs AS (SELECT osm.site_id,
+                             date(o.observed_at AT TIME ZONE 'NZST') AS day_observed_at,
+                             osm.measurement_name,
+                             o.amount
+                      FROM observations o
+                               LEFT JOIN observation_sites_measurements osm ON o.observation_measurement_id = osm.id
+                      WHERE osm.measurement_name IN ('Water Meter Reading', 'Water Meter Volume')
+                        AND o.observed_at > '2023-01-01 00:00:00+13')
+SELECT filtered_obs.site_id,
+       filtered_obs.day_observed_at,
+       filtered_obs.measurement_name,
+       CASE
+           WHEN filtered_obs.measurement_name = 'Water Meter Reading' THEN MAX(filtered_obs.amount) - MIN(filtered_obs.amount)
+           WHEN filtered_obs.measurement_name = 'Water Meter Volume' THEN SUM(filtered_obs.amount)
+           END AS daily_usage
+FROM filtered_obs
+GROUP BY filtered_obs.site_id,
+         filtered_obs.day_observed_at,
+         filtered_obs.measurement_name;
+

--- a/packages/Manager/src/test/kotlin/nz/govt/eop/plan_limits/WaterAllocationAndUsageViewsTest.kt
+++ b/packages/Manager/src/test/kotlin/nz/govt/eop/plan_limits/WaterAllocationAndUsageViewsTest.kt
@@ -17,8 +17,6 @@ import org.springframework.jdbc.core.JdbcTemplate
 import org.springframework.jdbc.support.GeneratedKeyHolder
 import org.springframework.jdbc.support.KeyHolder
 import org.springframework.test.context.ActiveProfiles
-import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*
-import org.springframework.test.web.servlet.result.MockMvcResultMatchers.*
 import org.springframework.transaction.annotation.Transactional
 
 data class WaterAllocationUsageRow(
@@ -171,7 +169,7 @@ class WaterAllocationAndUsageViewsTest(@Autowired val jdbcTemplate: JdbcTemplate
     // THEN
     val result = queryAllocationsAndUsage(whereClause)
     result.size shouldBe 1
-    result[0].dailyUsage.compareTo(BigDecimal(864)) shouldBe 0
+    result[0].dailyUsage shouldBe BigDecimal(10)
 
     // GIVEN
     createTestObservation(testSiteId, 5, observationDate.plusHours(1).toInstant(ZoneOffset.UTC))
@@ -181,7 +179,7 @@ class WaterAllocationAndUsageViewsTest(@Autowired val jdbcTemplate: JdbcTemplate
     val secondResult = queryAllocationsAndUsage(whereClause)
 
     // THEN
-    secondResult[0].dailyUsage.compareTo(BigDecimal(648)) shouldBe 0
+    secondResult[0].dailyUsage shouldBe BigDecimal(15)
   }
 
   @Test
@@ -338,7 +336,7 @@ class WaterAllocationAndUsageViewsTest(@Autowired val jdbcTemplate: JdbcTemplate
         testAllocation.allocation + secondAllocationInSameArea.allocation,
         testAllocation.meteredAllocationDaily + secondAllocationInSameArea.meteredAllocationDaily,
         testAllocation.meteredAllocationYearly + secondAllocationInSameArea.meteredAllocationYearly,
-        BigDecimal(1728))
+        BigDecimal(20))
 
     // WHEN
     val resultsInADifferentArea =
@@ -346,7 +344,7 @@ class WaterAllocationAndUsageViewsTest(@Autowired val jdbcTemplate: JdbcTemplate
             "where area_id = '${allocationInDifferentArea.areaId}' and date = '$observationDate'")
 
     // THEN
-    resultsInADifferentArea[0].dailyUsage.compareTo(BigDecimal(2592)) shouldBe 0
+    resultsInADifferentArea[0].dailyUsage shouldBe BigDecimal(30)
   }
 
   fun queryAllocationsAndUsage(whereClause: String): MutableList<WaterAllocationUsageRow> =
@@ -364,12 +362,11 @@ class WaterAllocationAndUsageViewsTest(@Autowired val jdbcTemplate: JdbcTemplate
   ) {
     results.forAll {
       if (areaId != null) it.areaId shouldBe areaId
-      if (allocation != null) it.allocation.compareTo(allocation) shouldBe 0
-      if (meteredAllocationDaily != null)
-          it.allocationDaily.compareTo(meteredAllocationDaily) shouldBe 0
+      if (allocation != null) it.allocation shouldBe allocation
+      if (meteredAllocationDaily != null) it.allocationDaily shouldBe meteredAllocationDaily
       if (meteredAllocationYearly != null)
-          it.meteredAllocationYearly.compareTo(meteredAllocationYearly) shouldBe 0
-      if (dailyUsage != null) it.dailyUsage.compareTo(dailyUsage) shouldBe 0
+          it.meteredAllocationYearly shouldBe meteredAllocationYearly
+      if (dailyUsage != null) it.dailyUsage shouldBe dailyUsage
     }
   }
 


### PR DESCRIPTION
- Move data to NZST timezone when aggregating daily
- Fix issue with Water Meter Volume, previously we were treating it as a l/s value when it is actually a raw M^3 used since the last data point. Which makes the aggregation a simple sum