### PR TITLE
Daily Usage Graph

### DIFF
--- a/packages/Manager/src/main/resources/db/migration/R__2_gwrc_plan_data.sql
+++ b/packages/Manager/src/main/resources/db/migration/R__2_gwrc_plan_data.sql
@@ -440,7 +440,7 @@ VALUES
             },
             {
               "id": "493cb5ae-4086-4649-8d3a-6d41ee9fded7",
-              "name": "Ruamahanga Whaitua",
+              "name": "Ruamāhanga Whaitua",
               "referenceUrl": "https://www.gw.govt.nz/assets/Documents/2023/07/Chapter-7.pdf",
               "boundaryId": "5f4835dd489ae103689e742430de37f92067f64fe3e8dddb5ba77e39659b9808",
               "groundwaterLimits": [

--- a/packages/PlanLimitsUI/package-lock.json
+++ b/packages/PlanLimitsUI/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@headlessui/react": "^1.7.17",
         "@heroicons/react": "^2.0.18",
+        "@nivo/calendar": "^0.83.0",
         "@nivo/heatmap": "^0.83.0",
         "@tanstack/react-query": "^5.0.0",
         "date-fns": "^2.30.0",
@@ -809,6 +810,31 @@
       "peerDependencies": {
         "react": ">= 16.14.0 < 19.0.0"
       }
+    },
+    "node_modules/@nivo/calendar": {
+      "version": "0.83.0",
+      "resolved": "https://registry.npmjs.org/@nivo/calendar/-/calendar-0.83.0.tgz",
+      "integrity": "sha512-LC7oNJFkMoivb2IbCwWQY0isTGjppMA6jwJtlxLcwP7VD1LXV/a2ZRIbvLhCvEgHQpMuKlBtTI6Q2w+t3KrAKA==",
+      "dependencies": {
+        "@nivo/core": "0.83.0",
+        "@nivo/legends": "0.83.0",
+        "@nivo/tooltip": "0.83.0",
+        "@types/d3-scale": "^3.2.3",
+        "@types/d3-time": "^1.0.10",
+        "@types/d3-time-format": "^3.0.0",
+        "d3-scale": "^3.2.3",
+        "d3-time": "^1.0.10",
+        "d3-time-format": "^3.0.0",
+        "lodash": "^4.17.21"
+      },
+      "peerDependencies": {
+        "react": ">= 16.14.0 < 19.0.0"
+      }
+    },
+    "node_modules/@nivo/calendar/node_modules/@types/d3-time-format": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-time-format/-/d3-time-format-3.0.4.tgz",
+      "integrity": "sha512-or9DiDnYI1h38J9hxKEsw513+KVuFbEVhl7qdxcaudoiqWWepapUen+2vAriFGexr6W5+P4l9+HJrB39GG+oRg=="
     },
     "node_modules/@nivo/colors": {
       "version": "0.83.0",
@@ -9723,6 +9749,30 @@
         "d3-format": "^1.4.4",
         "d3-time-format": "^3.0.0",
         "prop-types": "^15.7.2"
+      }
+    },
+    "@nivo/calendar": {
+      "version": "0.83.0",
+      "resolved": "https://registry.npmjs.org/@nivo/calendar/-/calendar-0.83.0.tgz",
+      "integrity": "sha512-LC7oNJFkMoivb2IbCwWQY0isTGjppMA6jwJtlxLcwP7VD1LXV/a2ZRIbvLhCvEgHQpMuKlBtTI6Q2w+t3KrAKA==",
+      "requires": {
+        "@nivo/core": "0.83.0",
+        "@nivo/legends": "0.83.0",
+        "@nivo/tooltip": "0.83.0",
+        "@types/d3-scale": "^3.2.3",
+        "@types/d3-time": "^1.0.10",
+        "@types/d3-time-format": "^3.0.0",
+        "d3-scale": "^3.2.3",
+        "d3-time": "^1.0.10",
+        "d3-time-format": "^3.0.0",
+        "lodash": "^4.17.21"
+      },
+      "dependencies": {
+        "@types/d3-time-format": {
+          "version": "3.0.4",
+          "resolved": "https://registry.npmjs.org/@types/d3-time-format/-/d3-time-format-3.0.4.tgz",
+          "integrity": "sha512-or9DiDnYI1h38J9hxKEsw513+KVuFbEVhl7qdxcaudoiqWWepapUen+2vAriFGexr6W5+P4l9+HJrB39GG+oRg=="
+        }
       }
     },
     "@nivo/colors": {

--- a/packages/PlanLimitsUI/package.json
+++ b/packages/PlanLimitsUI/package.json
@@ -15,6 +15,7 @@
   "dependencies": {
     "@headlessui/react": "^1.7.17",
     "@heroicons/react": "^2.0.18",
+    "@nivo/calendar": "^0.83.0",
     "@nivo/heatmap": "^0.83.0",
     "@tanstack/react-query": "^5.0.0",
     "date-fns": "^2.30.0",

--- a/packages/PlanLimitsUI/src/global.d.ts
+++ b/packages/PlanLimitsUI/src/global.d.ts
@@ -48,6 +48,7 @@ interface Council {
 interface UsageDisplayGroup {
   name: string;
   hideLabel: boolean;
+  showLegend: boolean;
   areaIds: string[];
 }
 

--- a/packages/PlanLimitsUI/src/global.d.ts
+++ b/packages/PlanLimitsUI/src/global.d.ts
@@ -191,6 +191,20 @@ interface WeeklyUsageHeatmapDataItem extends HeatmapDataItem {
   endOfWeek: Date;
 }
 
+interface DailyUsageTimeRangeDataItem extends CalendarTooltipProps {
+  date: Date;
+  value: number;
+  usage: number;
+  allocation: number;
+}
+
+interface DailyUsageHeatmapDataItem extends HeatmapDataItem {
+  date: Date;
+  value: number;
+  usage: number;
+  allocation: number;
+}
+
 interface UsageHeatmapDataItem extends HeatmapDataItem {
   usage: number;
   allocation: number;

--- a/packages/PlanLimitsUI/src/global.d.ts
+++ b/packages/PlanLimitsUI/src/global.d.ts
@@ -182,27 +182,14 @@ interface GroundwaterLimitView {
   subUnitLimitView: LimitView;
 }
 
+interface HeatmapData {
+  id: string;
+  data: HeatmapDataItem[];
+}
+
 interface HeatmapDataItem {
   x: string;
   y: number;
-}
-
-interface WeeklyUsageHeatmapDataItem extends HeatmapDataItem {
-  endOfWeek: Date;
-}
-
-interface DailyUsageTimeRangeDataItem extends CalendarTooltipProps {
-  date: Date;
-  value: number;
-  usage: number;
-  allocation: number;
-}
-
-interface DailyUsageHeatmapDataItem extends HeatmapDataItem {
-  date: Date;
-  value: number;
-  usage: number;
-  allocation: number;
 }
 
 interface UsageHeatmapDataItem extends HeatmapDataItem {
@@ -210,7 +197,21 @@ interface UsageHeatmapDataItem extends HeatmapDataItem {
   allocation: number;
 }
 
-interface HeatmapData {
-  id: string;
-  data: HeatmapDataItem[];
+interface WeeklyUsageHeatmapDataItem extends HeatmapDataItem {
+  endOfWeek: Date;
 }
+
+interface PopulatedDailyUsageHeatmapDataItem extends HeatmapDataItem {
+  date: Date;
+  usage: number;
+  allocation: number;
+}
+
+interface EmptyDailyUsageHeatmapDataItem {
+  x: string;
+  y: null;
+}
+
+type DailyUsageHeatmapDataItem =
+  | PopulatedDailyUsageHeatmapDataItem
+  | EmptyDailyUsageHeatmapDataItem;

--- a/packages/PlanLimitsUI/src/lib/councilData.tsx
+++ b/packages/PlanLimitsUI/src/lib/councilData.tsx
@@ -75,6 +75,7 @@ export const Councils: Council[] = [
       {
         name: 'Kāpiti',
         hideLabel: false,
+        showLegend: true,
         areaIds: [
           'WaitohuSW',
           'OtakiSW',
@@ -91,6 +92,7 @@ export const Councils: Council[] = [
       {
         name: 'Te Awarua-o-Porirua Whaitua',
         hideLabel: false,
+        showLegend: true,
         areaIds: [
           'HuttSW',
           'Upper HuttGW',
@@ -102,6 +104,7 @@ export const Councils: Council[] = [
       {
         name: 'Ruamahanga',
         hideLabel: false,
+        showLegend: false,
         areaIds: [
           'RuamahangaTotalSW',
           'Ruamahanga_UpperSW',
@@ -116,6 +119,7 @@ export const Councils: Council[] = [
       {
         name: 'Ruamahanga 2',
         hideLabel: true,
+        showLegend: false,
         areaIds: [
           'Ruamahanga_MiddleSW',
           'Middle RuamahangaGW',
@@ -133,6 +137,7 @@ export const Councils: Council[] = [
       {
         name: 'Ruamahanga 3',
         hideLabel: true,
+        showLegend: false,
         areaIds: [
           'LakeWairarapaSW',
           'LakeGW',
@@ -144,6 +149,7 @@ export const Councils: Council[] = [
       {
         name: 'Ruamahanga 4',
         hideLabel: true,
+        showLegend: true,
         areaIds: [
           'Ruamahanga_LowerSW',
           'MoikiGW',

--- a/packages/PlanLimitsUI/src/lib/councilData.tsx
+++ b/packages/PlanLimitsUI/src/lib/councilData.tsx
@@ -90,7 +90,7 @@ export const Councils: Council[] = [
         ],
       },
       {
-        name: 'Te Awarua-o-Porirua Whaitua',
+        name: 'Te Whanganui a Tara',
         hideLabel: false,
         showLegend: true,
         areaIds: [

--- a/packages/PlanLimitsUI/src/lib/councilData.tsx
+++ b/packages/PlanLimitsUI/src/lib/councilData.tsx
@@ -102,7 +102,7 @@ export const Councils: Council[] = [
         ],
       },
       {
-        name: 'Ruamahanga',
+        name: 'Ruamāhanga',
         hideLabel: false,
         showLegend: false,
         areaIds: [

--- a/packages/PlanLimitsUI/src/lib/useDetailedWaterUseData.ts
+++ b/packages/PlanLimitsUI/src/lib/useDetailedWaterUseData.ts
@@ -36,7 +36,6 @@ export default function useDetailedWaterUseData(
     data,
   };
 }
-
 export type DetailedWaterUseQuery = ReturnType<typeof useDetailedWaterUseData>;
 
 function transformWaterUseData(
@@ -47,11 +46,11 @@ function transformWaterUseData(
   const areaUsage = groupBy<ParsedUsage>(parsedUsage, 'areaId');
 
   const groupedAreaUsage = displayGroups.map((group) => {
-    const data: HeatmapData[] = [];
+    const weeklyData: HeatmapData[] = [];
     const missingAreas: string[] = [];
     group.areaIds.forEach((areaId) => {
       if (areaUsage[areaId]) {
-        data.push(transformUsageToHeatmapData(areaId, areaUsage[areaId]));
+        weeklyData.push(transformUsageToHeatmapData(areaId, areaUsage[areaId]));
       } else {
         missingAreas.push(areaId);
       }
@@ -59,7 +58,7 @@ function transformWaterUseData(
 
     return {
       ...group,
-      data,
+      weeklyData,
       missingAreas,
     };
   });
@@ -69,6 +68,7 @@ function transformWaterUseData(
     groups: groupedAreaUsage,
   };
 }
+export type GroupedWaterUseData = ReturnType<typeof transformWaterUseData>;
 
 function parseUsage(usage: Usage[]) {
   return usage.map((usage) => {

--- a/packages/PlanLimitsUI/src/lib/useDetailedWaterUseData.ts
+++ b/packages/PlanLimitsUI/src/lib/useDetailedWaterUseData.ts
@@ -132,7 +132,7 @@ function transformUsageToDailyHeatmapData(
     usage.map((usage) => {
       return {
         day: usage.date,
-        value: usage.usagePercent,
+        value: usage.usagePercent * 100,
         usage: usage.dailyUsage,
         allocation: usage.meteredDailyAllocation,
       };

--- a/packages/PlanLimitsUI/src/pages/Limits/Sidebar/UsageTable.tsx
+++ b/packages/PlanLimitsUI/src/pages/Limits/Sidebar/UsageTable.tsx
@@ -43,7 +43,12 @@ export default function UsageTable({
 
   return (
     <>
-      <h3 className="text-lg uppercase mb-2 tracking-wider">Usage</h3>
+      <h3 className="text-lg uppercase mb-2 tracking-wider">Water Use</h3>
+      <p className="mb-2">
+        The data below <strong>is not all Water Use data</strong> supplied to
+        Greater Wellington. It only includes data provided using timely
+        automated telemetered systems.
+      </p>
       <div className="flex justify-between mb-4">
         <div className="text-sm">
           For week ending {format(waterUseData.data.to, 'do LLLL y')}
@@ -105,7 +110,7 @@ function Table({
         <tr>
           <th className="w-12"></th>
           <th className="border p-2 text-sm font-normal bg-gray-100">
-            Water Use
+            % of Consented Water Used
           </th>
         </tr>
       </thead>

--- a/packages/PlanLimitsUI/src/pages/Usage/DailyResults.tsx
+++ b/packages/PlanLimitsUI/src/pages/Usage/DailyResults.tsx
@@ -40,19 +40,32 @@ export default function WeeklyResults({ data, from, to }: Props) {
                       </a>
                     </div>
 
-                    <div className="h-36">
+                    <div className="h-40">
                       <ResponsiveTimeRange
                         data={dailyData.data}
                         from={from}
                         to={to}
                         tooltip={CustomTooltip}
-                        margin={{ top: 20, right: 60, bottom: 0, left: 60 }}
+                        margin={{ top: 20, right: 60, bottom: 20, left: 60 }}
                         weekdayTicks={[0, 1, 2, 3, 4, 5, 6]}
                         dayBorderWidth={1}
                         dayBorderColor={'#ddd'}
                         minValue={0}
-                        maxValue={1}
+                        maxValue={100}
                         colors={last(schemeOranges)}
+                        legends={[
+                          {
+                            anchor: 'bottom',
+                            itemWidth: 28,
+                            itemHeight: 36,
+                            itemsSpacing: 14,
+                            symbolSize: 10,
+                            itemCount: 10,
+                            justify: true,
+                            direction: 'row',
+                            translateY: -10,
+                          },
+                        ]}
                       />
                     </div>
                   </div>

--- a/packages/PlanLimitsUI/src/pages/Usage/DailyResults.tsx
+++ b/packages/PlanLimitsUI/src/pages/Usage/DailyResults.tsx
@@ -1,0 +1,31 @@
+import { ResponsiveHeatMapCanvas, type ComputedCell } from '@nivo/heatmap';
+import { format } from 'date-fns';
+import type { GroupedWaterUseData } from '../../lib/useDetailedWaterUseData';
+
+export default function WeeklyResults({ data }: { data: GroupedWaterUseData }) {
+  return (
+    <>
+      <h2 className="text-xl mb-2">Daily usage grouped by area</h2>
+      {data.groups.map((usageGroup) => {
+        return (
+          <div key={usageGroup.name} className="mb-6">
+            {!usageGroup.hideLabel ? (
+              <h2 className="text-lg mb-2">{usageGroup.name}</h2>
+            ) : (
+              <></>
+            )}
+            <div className="mb-4">
+              {usageGroup.areaIds.map((areaId) => {
+                return (
+                  <div key={areaId} className="mb-6">
+                    <h3>{areaId}</h3>
+                  </div>
+                );
+              })}
+            </div>
+          </div>
+        );
+      })}
+    </>
+  );
+}

--- a/packages/PlanLimitsUI/src/pages/Usage/DailyResults.tsx
+++ b/packages/PlanLimitsUI/src/pages/Usage/DailyResults.tsx
@@ -33,10 +33,10 @@ export default function WeeklyResults({ data, from, to }: Props) {
                         </h3>
                       </div>
                       <a
-                        className="underline text-sm mr-16"
+                        className="underline text-xs mr-16"
                         href={`#weekly-usage-${usageGroup.name}`}
                       >
-                        Back to top
+                        ↑ Back to top
                       </a>
                     </div>
 
@@ -58,12 +58,12 @@ export default function WeeklyResults({ data, from, to }: Props) {
                             anchor: 'bottom',
                             itemWidth: 28,
                             itemHeight: 36,
-                            itemsSpacing: 14,
+                            itemsSpacing: 12,
                             symbolSize: 10,
                             itemCount: 10,
                             justify: true,
                             direction: 'row',
-                            translateY: -10,
+                            translateY: -15,
                           },
                         ]}
                       />

--- a/packages/PlanLimitsUI/src/pages/Usage/DailyResults.tsx
+++ b/packages/PlanLimitsUI/src/pages/Usage/DailyResults.tsx
@@ -1,3 +1,9 @@
+import {
+  ResponsiveHeatMapCanvas,
+  type ComputedCell,
+  type CellCanvasRendererProps,
+  type HeatMapDatum,
+} from '@nivo/heatmap';
 import { ResponsiveTimeRange, type CalendarTooltipProps } from '@nivo/calendar';
 import { format } from 'date-fns';
 import type { GroupedWaterUseData } from '../../lib/useDetailedWaterUseData';
@@ -9,6 +15,7 @@ interface Props {
   from: string;
   to: string;
 }
+const formatNumber = Intl.NumberFormat();
 
 export default function WeeklyResults({ data, from, to }: Props) {
   return (
@@ -23,10 +30,10 @@ export default function WeeklyResults({ data, from, to }: Props) {
               <></>
             )}
             <div>
-              {usageGroup.dailyData.map((dailyData) => {
+              {usageGroup.dailyData.map((dailyData, index) => {
                 return (
                   <div key={dailyData.areaId} className="mb-4">
-                    <div className="flex items-baseline justify-between mb-2">
+                    <div className="flex items-baseline justify-between">
                       <div>
                         <h3 id={`daily-usage-${dailyData.areaId}`}>
                           Daily usage for {dailyData.areaId}
@@ -39,35 +46,13 @@ export default function WeeklyResults({ data, from, to }: Props) {
                         ↑ Back to top
                       </a>
                     </div>
-
-                    <div className="h-40">
-                      <ResponsiveTimeRange
-                        data={dailyData.data}
-                        from={from}
-                        to={to}
-                        tooltip={CustomTooltip}
-                        margin={{ top: 20, right: 60, bottom: 20, left: 60 }}
-                        weekdayTicks={[0, 1, 2, 3, 4, 5, 6]}
-                        dayBorderWidth={1}
-                        dayBorderColor={'#ddd'}
-                        minValue={0}
-                        maxValue={100}
-                        colors={last(schemeOranges)}
-                        legends={[
-                          {
-                            anchor: 'bottom',
-                            itemWidth: 28,
-                            itemHeight: 36,
-                            itemsSpacing: 12,
-                            symbolSize: 10,
-                            itemCount: 10,
-                            justify: true,
-                            direction: 'row',
-                            translateY: -15,
-                          },
-                        ]}
-                      />
-                    </div>
+                    <TimeRangeResult
+                      dailyData={dailyData}
+                      from={from}
+                      to={to}
+                    />
+                    <h4 className="font-semibold">Alternate graph type</h4>
+                    <HeatmapResult dailyData={usageGroup.dailyDataAlt[index]} />
                   </div>
                 );
               })}
@@ -79,6 +64,97 @@ export default function WeeklyResults({ data, from, to }: Props) {
   );
 }
 
+function TimeRangeResult({
+  dailyData,
+  from,
+  to,
+}: {
+  dailyData: any;
+  from: string;
+  to: string;
+}) {
+  return (
+    <div className="h-40 w-full">
+      <ResponsiveTimeRange
+        data={dailyData.data}
+        from={from}
+        to={to}
+        tooltip={CustomTooltip}
+        margin={{ top: 20, right: 60, bottom: 20, left: 60 }}
+        weekdayTicks={[0, 1, 2, 3, 4, 5, 6]}
+        dayBorderWidth={1}
+        dayBorderColor={'#ddd'}
+        square={false}
+        minValue={0}
+        maxValue={100}
+        colors={last(schemeOranges)}
+        legends={[
+          {
+            anchor: 'bottom',
+            itemWidth: 28,
+            itemHeight: 36,
+            itemsSpacing: 12,
+            symbolSize: 10,
+            itemCount: 10,
+            justify: true,
+            direction: 'row',
+            translateY: -10,
+          },
+        ]}
+      />
+    </div>
+  );
+}
+
+function HeatmapResult({ dailyData }: { dailyData: any }) {
+  return (
+    <div key={`daily-alt-${dailyData.areaId}`} className="mb-6">
+      <div className="w-full" style={{ height: `200px` }}>
+        <ResponsiveHeatMapCanvas
+          data={dailyData.data}
+          margin={{
+            top: 0,
+            right: 50,
+            bottom: 0,
+            left: 130,
+          }}
+          forceSquare={true}
+          colors={{
+            type: 'sequential',
+            scheme: 'oranges',
+            minValue: 0,
+            maxValue: 1,
+          }}
+          enableLabels={false}
+          tooltip={CustomTooltipAlt}
+          axisTop={false}
+          borderWidth={1}
+          borderColor={'#ddd'}
+          emptyColor={'#fff'}
+          renderCell={renderRect}
+          axisLeft={{
+            tickSize: 0,
+          }}
+          animate={false}
+          legends={[
+            {
+              anchor: 'bottom',
+              direction: 'row',
+              translateY: 35,
+              title: 'Daily usage (%) →',
+              length: 300,
+              titleOffset: 5,
+              titleAlign: 'middle',
+              thickness: 10,
+              tickFormat: '=-0.0~%',
+            },
+          ]}
+        />
+      </div>
+    </div>
+  );
+}
+
 function CustomTooltip(data: CalendarTooltipProps) {
   return (
     <div className="bg-gray-500 text-white opacity-90 text-xs p-2 rounded shadow">
@@ -86,7 +162,77 @@ function CustomTooltip(data: CalendarTooltipProps) {
       <br />
       <strong>{round(data.value, 1)}%</strong>
       <br />
-      {data.usage} of {data.allocation} m<sup>3</sup>/day
+      {formatNumber.format(data.usage)} of{' '}
+      {formatNumber.format(data.allocation)} m<sup>3</sup>/day
     </div>
   );
 }
+
+function CustomTooltipAlt({
+  cell,
+}: {
+  cell: ComputedCell<WeeklyUsageHeatmapDataItem>;
+}) {
+  return (
+    <div className="bg-gray-500 text-white opacity-90 text-xs p-2 rounded shadow">
+      {cell.data.date && (
+        <>
+          <strong>{format(cell.data.date, 'EEEE do MMMM yyyy')}</strong>
+          <br />
+          <strong>{round(cell.data.y * 100, 1)}%</strong>
+          <br />
+          {formatNumber.format(cell.data.usage)} of{' '}
+          {formatNumber.format(cell.data.allocation)} m<sup>3</sup>/day
+          <br />
+        </>
+      )}
+      {!cell.data.date && <strong>No data</strong>}
+    </div>
+  );
+}
+
+export const renderRect = <Datum extends HeatMapDatum>(
+  ctx: CanvasRenderingContext2D,
+  {
+    cell: {
+      x,
+      y,
+      width,
+      height,
+      color,
+      borderColor,
+      opacity,
+      labelTextColor,
+      label,
+    },
+    borderWidth,
+    enableLabels,
+    theme,
+  }: CellCanvasRendererProps<Datum>,
+) => {
+  ctx.save();
+  ctx.globalAlpha = opacity;
+
+  ctx.fillStyle = color;
+  if (borderWidth > 0) {
+    ctx.strokeStyle = borderColor;
+    ctx.lineWidth = borderWidth;
+  }
+
+  ctx.fillRect(x - width / 2, y - height / 2, width, height);
+  if (borderWidth > 0) {
+    ctx.strokeRect(x - width / 2, y - height / 2, width, height);
+  }
+
+  if (enableLabels) {
+    ctx.fillStyle = labelTextColor;
+    ctx.font = `${
+      theme.labels.text.fontWeight ? `${theme.labels.text.fontWeight} ` : ''
+    }${theme.labels.text.fontSize}px ${theme.labels.text.fontFamily}`;
+    ctx.textAlign = 'center';
+    ctx.textBaseline = 'middle';
+    ctx.fillText(label, x, y);
+  }
+
+  ctx.restore();
+};

--- a/packages/PlanLimitsUI/src/pages/Usage/DailyResults.tsx
+++ b/packages/PlanLimitsUI/src/pages/Usage/DailyResults.tsx
@@ -1,3 +1,5 @@
+import { last, round } from 'lodash';
+import { format, getWeekOfMonth } from 'date-fns';
 import {
   ResponsiveHeatMapCanvas,
   type ComputedCell,
@@ -5,10 +7,8 @@ import {
   type HeatMapDatum,
 } from '@nivo/heatmap';
 import { ResponsiveTimeRange, type CalendarTooltipProps } from '@nivo/calendar';
-import { format, getWeekOfMonth } from 'date-fns';
-import type { GroupedWaterUseData } from '../../lib/useDetailedWaterUseData';
 import { schemeOranges } from 'd3-scale-chromatic';
-import { last, round } from 'lodash';
+import type { GroupedWaterUseData } from '../../lib/useDetailedWaterUseData';
 
 interface Props {
   data: GroupedWaterUseData;
@@ -25,17 +25,20 @@ export default function WeeklyResults({ data, from, to }: Props) {
         return (
           <div key={usageGroup.name} className="my-6 border-b">
             {!usageGroup.hideLabel ? (
-              <h2 className="text-lg mb-2 uppercase">{usageGroup.name}</h2>
+              <h2 className="text-lg mb-2">{usageGroup.name}</h2>
             ) : (
               <></>
             )}
             <div>
               {usageGroup.dailyData.map((dailyData, index) => {
                 return (
-                  <div key={dailyData.areaId} className="mb-4">
+                  <div key={dailyData.areaId} className="mb-6">
                     <div className="flex items-baseline justify-between">
                       <div>
-                        <h3 id={`daily-usage-${dailyData.areaId}`}>
+                        <h3
+                          id={`daily-usage-${dailyData.areaId}`}
+                          className="mb-2"
+                        >
                           Daily usage for {dailyData.areaId}
                         </h3>
                       </div>
@@ -51,7 +54,7 @@ export default function WeeklyResults({ data, from, to }: Props) {
                       from={from}
                       to={to}
                     />
-                    <h4 className="font-semibold">Alternate graph type</h4>
+                    <p className="italic text-sm">Alternate graph type</p>
                     <HeatmapResult dailyData={usageGroup.dailyDataAlt[index]} />
                   </div>
                 );
@@ -74,7 +77,7 @@ function TimeRangeResult({
   to: string;
 }) {
   return (
-    <div className="h-40 w-full">
+    <div className="h-40">
       <ResponsiveTimeRange
         data={dailyData.data}
         from={from}
@@ -98,7 +101,7 @@ function TimeRangeResult({
             itemCount: 10,
             justify: true,
             direction: 'row',
-            translateY: -10,
+            translateY: -15,
           },
         ]}
       />
@@ -108,69 +111,72 @@ function TimeRangeResult({
 
 function HeatmapResult({ dailyData }: { dailyData: any }) {
   return (
-    <div key={`daily-alt-${dailyData.areaId}`} className="mb-6">
-      <div className="w-full" style={{ height: `200px` }}>
-        <ResponsiveHeatMapCanvas
-          data={dailyData.data}
-          margin={{
-            top: 0,
-            right: 50,
-            bottom: 20,
-            left: 130,
-          }}
-          forceSquare={true}
-          colors={{
-            type: 'sequential',
-            scheme: 'oranges',
-            minValue: 0,
-            maxValue: 1,
-          }}
-          enableLabels={false}
-          tooltip={CustomTooltipAlt}
-          borderWidth={1}
-          borderColor={'#ddd'}
-          emptyColor={'#fff'}
-          renderCell={renderRect}
-          axisLeft={{
-            tickSize: 0,
-          }}
-          axisTop={{
-            tickSize: 0,
-            format: (endOfWeekAsJSONDate: string) => {
-              const date = new Date(endOfWeekAsJSONDate);
-              const weekOfMonth = getWeekOfMonth(date);
-              return weekOfMonth === 1 ? format(date, 'MMM') : '';
-            },
-          }}
-          animate={false}
-          legends={[
-            {
-              anchor: 'bottom',
-              direction: 'row',
-              translateY: 35,
-              title: 'Daily usage (%) →',
-              length: 300,
-              titleOffset: 5,
-              titleAlign: 'middle',
-              thickness: 10,
-              tickFormat: '=-0.0~%',
-            },
-          ]}
-        />
-      </div>
+    <div className="h-48">
+      <ResponsiveHeatMapCanvas
+        data={dailyData.data}
+        enableLabels={false}
+        renderCell={renderRect}
+        tooltip={CustomTooltipAlt}
+        forceSquare={true}
+        margin={{
+          top: 0,
+          right: 50,
+          bottom: 25,
+          left: 130,
+        }}
+        colors={{
+          type: 'sequential',
+          scheme: 'oranges',
+          minValue: 0,
+          maxValue: 1,
+        }}
+        borderWidth={1}
+        borderColor={'#ddd'}
+        emptyColor={'#fff'}
+        axisLeft={{
+          tickSize: 0,
+        }}
+        axisTop={{
+          tickSize: 0,
+          format: (endOfWeekAsJSONDate: string) => {
+            const date = new Date(endOfWeekAsJSONDate);
+            const weekOfMonth = getWeekOfMonth(date);
+            return weekOfMonth === 1 ? format(date, 'MMM') : '';
+          },
+        }}
+        legends={[
+          {
+            anchor: 'bottom',
+            direction: 'row',
+            translateY: 35,
+            title: 'Daily usage (%) →',
+            length: 300,
+            titleOffset: 5,
+            titleAlign: 'middle',
+            thickness: 10,
+            tickFormat: '=-0~%',
+          },
+        ]}
+      />
     </div>
   );
 }
 
-function CustomTooltip(data: CalendarTooltipProps) {
+function CustomTooltip(data: DailyUsageTimeRangeDataItem) {
   return (
     <div className="bg-gray-500 text-white opacity-90 text-xs p-2 rounded shadow">
-      <strong>{format(data.date, 'EEEE do MMMM yyyy')}</strong>
-      <br />
-      <strong>{round(data.value, 1)}%</strong>
-      <br />
-      {formatNumber.format(data.usage)} of{' '}
-      {formatNumber.format(data.allocation)} m<sup>3</sup>/day
+      <>
+        <div className="font-semibold">
+          {format(data.date, 'EEEE do MMMM yyyy')}
+        </div>
+        <div>
+          Usage:{' '}
+          <span className="font-semibold">
+            {round(data.value, 1)}% ({formatNumber.format(data.usage)} of{' '}
+            {formatNumber.format(data.allocation)} m<sup>3</sup>/day)
+          </span>
+        </div>
+      </>
     </div>
   );
 }
@@ -178,26 +184,33 @@ function CustomTooltip(data: CalendarTooltipProps) {
 function CustomTooltipAlt({
   cell,
 }: {
-  cell: ComputedCell<WeeklyUsageHeatmapDataItem>;
+  cell: ComputedCell<DailyUsageHeatmapDataItem>;
 }) {
   return (
     <div className="bg-gray-500 text-white opacity-90 text-xs p-2 rounded shadow">
+      {!cell.data.date && <strong>No data</strong>}
+
       {cell.data.date && (
         <>
-          <strong>{format(cell.data.date, 'EEEE do MMMM yyyy')}</strong>
-          <br />
-          <strong>{round(cell.data.y * 100, 1)}%</strong>
-          <br />
-          {formatNumber.format(cell.data.usage)} of{' '}
-          {formatNumber.format(cell.data.allocation)} m<sup>3</sup>/day
-          <br />
+          <div className="font-semibold">
+            {format(cell.data.date, 'EEEE do MMMM yyyy')}
+          </div>
+          <div>
+            Usage:{' '}
+            <span className="font-semibold">
+              {round(cell.data.y * 100, 1)}% (
+              {formatNumber.format(cell.data.usage)} of{' '}
+              {formatNumber.format(cell.data.allocation)} m<sup>3</sup>/day)
+            </span>
+          </div>
         </>
       )}
-      {!cell.data.date && <strong>No data</strong>}
     </div>
   );
 }
 
+// Copied from https://github.com/plouc/nivo/blob/6dc6636cb64135104264547f05a3f44c787c6508/packages/heatmap/src/canvas.tsx
+// so we can customise as needed
 export const renderRect = <Datum extends HeatMapDatum>(
   ctx: CanvasRenderingContext2D,
   {

--- a/packages/PlanLimitsUI/src/pages/Usage/DailyResults.tsx
+++ b/packages/PlanLimitsUI/src/pages/Usage/DailyResults.tsx
@@ -1,24 +1,71 @@
-import { ResponsiveHeatMapCanvas, type ComputedCell } from '@nivo/heatmap';
+import { ResponsiveTimeRange } from '@nivo/calendar';
 import { format } from 'date-fns';
 import type { GroupedWaterUseData } from '../../lib/useDetailedWaterUseData';
 
-export default function WeeklyResults({ data }: { data: GroupedWaterUseData }) {
+interface Props {
+  data: GroupedWaterUseData;
+  from: string;
+  to: string;
+}
+
+export default function WeeklyResults({ data, from, to }: Props) {
   return (
     <>
       <h2 className="text-xl mb-2">Daily usage grouped by area</h2>
       {data.groups.map((usageGroup) => {
         return (
-          <div key={usageGroup.name} className="mb-6">
+          <div key={usageGroup.name} className="my-6 border-b">
             {!usageGroup.hideLabel ? (
-              <h2 className="text-lg mb-2">{usageGroup.name}</h2>
+              <h2 className="text-lg mb-2 uppercase">{usageGroup.name}</h2>
             ) : (
               <></>
             )}
-            <div className="mb-4">
-              {usageGroup.areaIds.map((areaId) => {
+            <div>
+              {usageGroup.dailyData.map((dailyData) => {
                 return (
-                  <div key={areaId} className="mb-6">
-                    <h3>{areaId}</h3>
+                  <div key={dailyData.areaId} className="mb-4">
+                    <div className="flex items-baseline justify-between mb-2">
+                      <div>
+                        <h3 id={`daily-usage-${dailyData.areaId}`}>
+                          Daily usage for {dailyData.areaId}
+                        </h3>
+                      </div>
+                      <a
+                        className="underline text-sm mr-16"
+                        href={`#weekly-usage-${usageGroup.name}`}
+                      >
+                        Back to top
+                      </a>
+                    </div>
+
+                    <div className="h-36">
+                      <ResponsiveTimeRange
+                        data={dailyData.data}
+                        from={from}
+                        to={to}
+                        tooltip={(data) => (
+                          <div className="bg-gray-500 text-white opacity-90 text-xs p-2 rounded shadow">
+                            <strong>
+                              {format(data.date, 'EEEE do MMMM yyyy')}
+                            </strong>
+                            <br />
+                            <strong>{data.value}%</strong>
+                            <br />
+                            {data.usage} of {data.allocation} m<sup>3</sup>/day
+                          </div>
+                        )}
+                        margin={{ top: 20, right: 60, bottom: 0, left: 60 }}
+                        weekdayTicks={[0, 1, 2, 3, 4, 5, 6]}
+                        dayBorderWidth={1}
+                        dayBorderColor={'#ddd'}
+                        // colors={[
+                        //   'rgb(254, 231, 208)',
+                        //   'rgb(252, 146, 68)',
+                        //   'rgb(240, 107, 24)',
+                        //   'rgb(206, 71, 3)',
+                        // ]}
+                      />
+                    </div>
                   </div>
                 );
               })}

--- a/packages/PlanLimitsUI/src/pages/Usage/DailyResults.tsx
+++ b/packages/PlanLimitsUI/src/pages/Usage/DailyResults.tsx
@@ -1,6 +1,8 @@
 import { ResponsiveTimeRange } from '@nivo/calendar';
 import { format } from 'date-fns';
 import type { GroupedWaterUseData } from '../../lib/useDetailedWaterUseData';
+import { schemeOranges } from 'd3-scale-chromatic';
+import { last } from 'lodash';
 
 interface Props {
   data: GroupedWaterUseData;
@@ -58,12 +60,9 @@ export default function WeeklyResults({ data, from, to }: Props) {
                         weekdayTicks={[0, 1, 2, 3, 4, 5, 6]}
                         dayBorderWidth={1}
                         dayBorderColor={'#ddd'}
-                        // colors={[
-                        //   'rgb(254, 231, 208)',
-                        //   'rgb(252, 146, 68)',
-                        //   'rgb(240, 107, 24)',
-                        //   'rgb(206, 71, 3)',
-                        // ]}
+                        minValue={0}
+                        maxValue={1}
+                        colors={last(schemeOranges)}
                       />
                     </div>
                   </div>

--- a/packages/PlanLimitsUI/src/pages/Usage/DailyResults.tsx
+++ b/packages/PlanLimitsUI/src/pages/Usage/DailyResults.tsx
@@ -1,4 +1,4 @@
-import { last, round } from 'lodash';
+import { round } from 'lodash';
 import { format, getWeekOfMonth } from 'date-fns';
 import {
   ResponsiveHeatMapCanvas,
@@ -6,9 +6,10 @@ import {
   type CellCanvasRendererProps,
   type HeatMapDatum,
 } from '@nivo/heatmap';
-import { ResponsiveTimeRange, type CalendarTooltipProps } from '@nivo/calendar';
-import { schemeOranges } from 'd3-scale-chromatic';
-import type { GroupedWaterUseData } from '../../lib/useDetailedWaterUseData';
+import type {
+  GroupedWaterUseData,
+  DailyHeatmapData,
+} from '../../lib/useDetailedWaterUseData';
 
 interface Props {
   data: GroupedWaterUseData;
@@ -17,7 +18,8 @@ interface Props {
 }
 const formatNumber = Intl.NumberFormat();
 
-export default function WeeklyResults({ data, from, to }: Props) {
+export default function DailyResults({ data }: Props) {
+  console.log(data);
   return (
     <>
       <h2 className="text-xl mb-2">Daily usage grouped by area</h2>
@@ -30,7 +32,7 @@ export default function WeeklyResults({ data, from, to }: Props) {
               <></>
             )}
             <div>
-              {usageGroup.dailyData.map((dailyData, index) => {
+              {usageGroup.dailyData.map((dailyData) => {
                 return (
                   <div key={dailyData.areaId} className="mb-6">
                     <div className="flex items-baseline justify-between">
@@ -49,13 +51,7 @@ export default function WeeklyResults({ data, from, to }: Props) {
                         ↑ Back to top
                       </a>
                     </div>
-                    <TimeRangeResult
-                      dailyData={dailyData}
-                      from={from}
-                      to={to}
-                    />
-                    <p className="italic text-sm">Alternate graph type</p>
-                    <HeatmapResult dailyData={usageGroup.dailyDataAlt[index]} />
+                    <HeatmapResult dailyData={dailyData} />
                   </div>
                 );
               })}
@@ -67,56 +63,14 @@ export default function WeeklyResults({ data, from, to }: Props) {
   );
 }
 
-function TimeRangeResult({
-  dailyData,
-  from,
-  to,
-}: {
-  dailyData: any;
-  from: string;
-  to: string;
-}) {
-  return (
-    <div className="h-40">
-      <ResponsiveTimeRange
-        data={dailyData.data}
-        from={from}
-        to={to}
-        tooltip={CustomTooltip}
-        margin={{ top: 20, right: 60, bottom: 20, left: 60 }}
-        weekdayTicks={[0, 1, 2, 3, 4, 5, 6]}
-        dayBorderWidth={1}
-        dayBorderColor={'#ddd'}
-        square={true}
-        minValue={0}
-        maxValue={100}
-        colors={last(schemeOranges)}
-        legends={[
-          {
-            anchor: 'bottom',
-            itemWidth: 28,
-            itemHeight: 36,
-            itemsSpacing: 12,
-            symbolSize: 10,
-            itemCount: 10,
-            justify: true,
-            direction: 'row',
-            translateY: -15,
-          },
-        ]}
-      />
-    </div>
-  );
-}
-
-function HeatmapResult({ dailyData }: { dailyData: any }) {
+function HeatmapResult({ dailyData }: { dailyData: DailyHeatmapData }) {
   return (
     <div className="h-48">
       <ResponsiveHeatMapCanvas
         data={dailyData.data}
         enableLabels={false}
         renderCell={renderRect}
-        tooltip={CustomTooltipAlt}
+        tooltip={CustomTooltip}
         forceSquare={true}
         margin={{
           top: 0,
@@ -162,35 +116,16 @@ function HeatmapResult({ dailyData }: { dailyData: any }) {
   );
 }
 
-function CustomTooltip(data: DailyUsageTimeRangeDataItem) {
-  return (
-    <div className="bg-gray-500 text-white opacity-90 text-xs p-2 rounded shadow">
-      <>
-        <div className="font-semibold">
-          {format(data.date, 'EEEE do MMMM yyyy')}
-        </div>
-        <div>
-          Usage:{' '}
-          <span className="font-semibold">
-            {round(data.value, 1)}% ({formatNumber.format(data.usage)} of{' '}
-            {formatNumber.format(data.allocation)} m<sup>3</sup>/day)
-          </span>
-        </div>
-      </>
-    </div>
-  );
-}
-
-function CustomTooltipAlt({
+function CustomTooltip({
   cell,
 }: {
   cell: ComputedCell<DailyUsageHeatmapDataItem>;
 }) {
   return (
     <div className="bg-gray-500 text-white opacity-90 text-xs p-2 rounded shadow">
-      {!cell.data.date && <strong>No data</strong>}
+      {cell.data.y === null && <strong>No data</strong>}
 
-      {cell.data.date && (
+      {cell.data.y !== null && (
         <>
           <div className="font-semibold">
             {format(cell.data.date, 'EEEE do MMMM yyyy')}

--- a/packages/PlanLimitsUI/src/pages/Usage/DailyResults.tsx
+++ b/packages/PlanLimitsUI/src/pages/Usage/DailyResults.tsx
@@ -5,7 +5,7 @@ import {
   type HeatMapDatum,
 } from '@nivo/heatmap';
 import { ResponsiveTimeRange, type CalendarTooltipProps } from '@nivo/calendar';
-import { format } from 'date-fns';
+import { format, getWeekOfMonth } from 'date-fns';
 import type { GroupedWaterUseData } from '../../lib/useDetailedWaterUseData';
 import { schemeOranges } from 'd3-scale-chromatic';
 import { last, round } from 'lodash';
@@ -84,7 +84,7 @@ function TimeRangeResult({
         weekdayTicks={[0, 1, 2, 3, 4, 5, 6]}
         dayBorderWidth={1}
         dayBorderColor={'#ddd'}
-        square={false}
+        square={true}
         minValue={0}
         maxValue={100}
         colors={last(schemeOranges)}
@@ -115,7 +115,7 @@ function HeatmapResult({ dailyData }: { dailyData: any }) {
           margin={{
             top: 0,
             right: 50,
-            bottom: 0,
+            bottom: 20,
             left: 130,
           }}
           forceSquare={true}
@@ -127,13 +127,20 @@ function HeatmapResult({ dailyData }: { dailyData: any }) {
           }}
           enableLabels={false}
           tooltip={CustomTooltipAlt}
-          axisTop={false}
           borderWidth={1}
           borderColor={'#ddd'}
           emptyColor={'#fff'}
           renderCell={renderRect}
           axisLeft={{
             tickSize: 0,
+          }}
+          axisTop={{
+            tickSize: 0,
+            format: (endOfWeekAsJSONDate: string) => {
+              const date = new Date(endOfWeekAsJSONDate);
+              const weekOfMonth = getWeekOfMonth(date);
+              return weekOfMonth === 1 ? format(date, 'MMM') : '';
+            },
           }}
           animate={false}
           legends={[

--- a/packages/PlanLimitsUI/src/pages/Usage/DailyResults.tsx
+++ b/packages/PlanLimitsUI/src/pages/Usage/DailyResults.tsx
@@ -1,8 +1,8 @@
-import { ResponsiveTimeRange } from '@nivo/calendar';
+import { ResponsiveTimeRange, type CalendarTooltipProps } from '@nivo/calendar';
 import { format } from 'date-fns';
 import type { GroupedWaterUseData } from '../../lib/useDetailedWaterUseData';
 import { schemeOranges } from 'd3-scale-chromatic';
-import { last } from 'lodash';
+import { last, round } from 'lodash';
 
 interface Props {
   data: GroupedWaterUseData;
@@ -45,17 +45,7 @@ export default function WeeklyResults({ data, from, to }: Props) {
                         data={dailyData.data}
                         from={from}
                         to={to}
-                        tooltip={(data) => (
-                          <div className="bg-gray-500 text-white opacity-90 text-xs p-2 rounded shadow">
-                            <strong>
-                              {format(data.date, 'EEEE do MMMM yyyy')}
-                            </strong>
-                            <br />
-                            <strong>{data.value}%</strong>
-                            <br />
-                            {data.usage} of {data.allocation} m<sup>3</sup>/day
-                          </div>
-                        )}
+                        tooltip={CustomTooltip}
                         margin={{ top: 20, right: 60, bottom: 0, left: 60 }}
                         weekdayTicks={[0, 1, 2, 3, 4, 5, 6]}
                         dayBorderWidth={1}
@@ -73,5 +63,17 @@ export default function WeeklyResults({ data, from, to }: Props) {
         );
       })}
     </>
+  );
+}
+
+function CustomTooltip(data: CalendarTooltipProps) {
+  return (
+    <div className="bg-gray-500 text-white opacity-90 text-xs p-2 rounded shadow">
+      <strong>{format(data.date, 'EEEE do MMMM yyyy')}</strong>
+      <br />
+      <strong>{round(data.value, 1)}%</strong>
+      <br />
+      {data.usage} of {data.allocation} m<sup>3</sup>/day
+    </div>
   );
 }

--- a/packages/PlanLimitsUI/src/pages/Usage/DailyResults.tsx
+++ b/packages/PlanLimitsUI/src/pages/Usage/DailyResults.tsx
@@ -69,7 +69,6 @@ function HeatmapResult({ dailyData }: { dailyData: DailyHeatmapData }) {
       <ResponsiveHeatMapCanvas
         data={dailyData.data}
         enableLabels={false}
-        renderCell={renderRect}
         tooltip={CustomTooltip}
         forceSquare={true}
         margin={{
@@ -143,51 +142,3 @@ function CustomTooltip({
     </div>
   );
 }
-
-// Copied from https://github.com/plouc/nivo/blob/6dc6636cb64135104264547f05a3f44c787c6508/packages/heatmap/src/canvas.tsx
-// so we can customise as needed
-export const renderRect = <Datum extends HeatMapDatum>(
-  ctx: CanvasRenderingContext2D,
-  {
-    cell: {
-      x,
-      y,
-      width,
-      height,
-      color,
-      borderColor,
-      opacity,
-      labelTextColor,
-      label,
-    },
-    borderWidth,
-    enableLabels,
-    theme,
-  }: CellCanvasRendererProps<Datum>,
-) => {
-  ctx.save();
-  ctx.globalAlpha = opacity;
-
-  ctx.fillStyle = color;
-  if (borderWidth > 0) {
-    ctx.strokeStyle = borderColor;
-    ctx.lineWidth = borderWidth;
-  }
-
-  ctx.fillRect(x - width / 2, y - height / 2, width, height);
-  if (borderWidth > 0) {
-    ctx.strokeRect(x - width / 2, y - height / 2, width, height);
-  }
-
-  if (enableLabels) {
-    ctx.fillStyle = labelTextColor;
-    ctx.font = `${
-      theme.labels.text.fontWeight ? `${theme.labels.text.fontWeight} ` : ''
-    }${theme.labels.text.fontSize}px ${theme.labels.text.fontFamily}`;
-    ctx.textAlign = 'center';
-    ctx.textBaseline = 'middle';
-    ctx.fillText(label, x, y);
-  }
-
-  ctx.restore();
-};

--- a/packages/PlanLimitsUI/src/pages/Usage/WeeklyResults.tsx
+++ b/packages/PlanLimitsUI/src/pages/Usage/WeeklyResults.tsx
@@ -75,6 +75,7 @@ function WeeklyUsageHeatMap({
         axisTop={axisTop}
         borderWidth={1}
         borderColor={'#ddd'}
+        emptyColor={'#fff'}
         axisLeft={{
           tickSize: 0,
         }}

--- a/packages/PlanLimitsUI/src/pages/Usage/WeeklyResults.tsx
+++ b/packages/PlanLimitsUI/src/pages/Usage/WeeklyResults.tsx
@@ -1,0 +1,92 @@
+import { ResponsiveHeatMapCanvas, type ComputedCell } from '@nivo/heatmap';
+import { format } from 'date-fns';
+import type { GroupedWaterUseData } from '../../lib/useDetailedWaterUseData';
+
+export default function WeeklyResults({ data }: { data: GroupedWaterUseData }) {
+  return (
+    <>
+      <h2 className="text-xl mb-2">Weekly usage grouped by area</h2>
+      {data.groups.map((usageGroup, index) => {
+        return (
+          <div key={usageGroup.name} className="mb-6">
+            {!usageGroup.hideLabel ? (
+              <h2 className="text-lg mb-2">{usageGroup.name}</h2>
+            ) : (
+              <></>
+            )}
+            <div className="mb-4">
+              <WeeklyUsageHeatMap
+                data={usageGroup.weeklyData}
+                showWeeks={index === 0}
+              ></WeeklyUsageHeatMap>
+            </div>
+          </div>
+        );
+      })}
+    </>
+  );
+}
+
+function WeeklyUsageHeatMap({
+  data,
+  showWeeks,
+}: {
+  data: HeatmapData[];
+  showWeeks: boolean;
+}) {
+  const axisTop = showWeeks
+    ? {
+        tickSize: 0,
+        tickRotation: -50,
+        legend: 'Week ending',
+        legendOffset: -65,
+      }
+    : undefined;
+
+  const marginTop = showWeeks ? 70 : 0;
+  const height = (data.length * 20 + marginTop).toString();
+
+  return (
+    <div className="w-full" style={{ height: `${height}px` }}>
+      <ResponsiveHeatMapCanvas
+        onClick={(cell) => {
+          window.location.href = `#daily-${cell.serieId}`;
+        }}
+        tooltip={CustomTooltip}
+        data={data}
+        valueFormat={'=-0.0~%'}
+        margin={{ top: marginTop, right: 50, bottom: 0, left: 130 }}
+        colors={{
+          type: 'sequential',
+          scheme: 'oranges',
+          minValue: 0,
+          maxValue: 1,
+        }}
+        enableLabels={false}
+        axisTop={axisTop}
+        borderWidth={1}
+        borderColor={'#ddd'}
+        axisLeft={{
+          tickSize: 0,
+        }}
+        animate={false}
+      />
+    </div>
+  );
+}
+
+const CustomTooltip = ({
+  cell,
+}: {
+  cell: ComputedCell<WeeklyUsageHeatmapDataItem>;
+}) => {
+  return (
+    <div className="bg-gray-500 text-white opacity-90 text-xs p-2 rounded shadow">
+      <span className="font-bold">{cell.serieId}</span>
+      <br />
+      Week ending {format(cell.data.endOfWeek, 'EEEE do MMMM yyyy')}
+      <br />
+      Median usage: <strong>{cell.formattedValue}</strong>
+    </div>
+  );
+};

--- a/packages/PlanLimitsUI/src/pages/Usage/WeeklyResults.tsx
+++ b/packages/PlanLimitsUI/src/pages/Usage/WeeklyResults.tsx
@@ -108,7 +108,7 @@ function CustomTooltip({
       <br />
       Week ending {format(cell.data.endOfWeek, 'EEEE do MMMM yyyy')}
       <br />
-      Median usage: <strong>{round(cell.value, 1)}%</strong>
+      Median usage: <strong>{round(cell.value * 100, 1)}%</strong>
     </div>
   );
 }

--- a/packages/PlanLimitsUI/src/pages/Usage/WeeklyResults.tsx
+++ b/packages/PlanLimitsUI/src/pages/Usage/WeeklyResults.tsx
@@ -1,7 +1,7 @@
 import { ResponsiveHeatMapCanvas, type ComputedCell } from '@nivo/heatmap';
 import { format } from 'date-fns';
-import type { GroupedWaterUseData } from '../../lib/useDetailedWaterUseData';
 import { round } from 'lodash';
+import type { GroupedWaterUseData } from '../../lib/useDetailedWaterUseData';
 
 export default function WeeklyResults({ data }: { data: GroupedWaterUseData }) {
   return (
@@ -14,10 +14,8 @@ export default function WeeklyResults({ data }: { data: GroupedWaterUseData }) {
             key={usageGroup.name}
             className="mb-4"
           >
-            {!usageGroup.hideLabel ? (
-              <h2 className="text-lg">{usageGroup.name}</h2>
-            ) : (
-              <></>
+            {!usageGroup.hideLabel && (
+              <h2 className="text-lg mb-2">{usageGroup.name}</h2>
             )}
             <div>
               <WeeklyUsageHeatMap
@@ -58,12 +56,13 @@ function WeeklyUsageHeatMap({
   return (
     <div className="w-full" style={{ height: `${height}px` }}>
       <ResponsiveHeatMapCanvas
+        data={data}
+        enableLabels={false}
         onClick={(cell) => {
           window.location.href = `#daily-usage-${cell.serieId}`;
         }}
         tooltip={CustomTooltip}
-        data={data}
-        valueFormat={'=-0.0~%'}
+        forceSquare={true}
         margin={{ top: marginTop, right: 50, bottom: marginBottom, left: 130 }}
         colors={{
           type: 'sequential',
@@ -71,15 +70,13 @@ function WeeklyUsageHeatMap({
           minValue: 0,
           maxValue: 1,
         }}
-        enableLabels={false}
-        axisTop={axisTop}
         borderWidth={1}
         borderColor={'#ddd'}
         emptyColor={'#fff'}
+        axisTop={axisTop}
         axisLeft={{
           tickSize: 0,
         }}
-        animate={false}
         legends={[
           {
             anchor: 'bottom',
@@ -90,7 +87,7 @@ function WeeklyUsageHeatMap({
             titleOffset: 5,
             titleAlign: 'middle',
             thickness: 10,
-            tickFormat: '=-0.0~%',
+            tickFormat: '=-0~%',
           },
         ]}
       />
@@ -105,11 +102,17 @@ function CustomTooltip({
 }) {
   return (
     <div className="bg-gray-500 text-white opacity-90 text-xs p-2 rounded shadow">
-      <span className="font-bold">{cell.serieId}</span>
-      <br />
-      Week ending {format(cell.data.endOfWeek, 'EEEE do MMMM yyyy')}
-      <br />
-      Median usage: <strong>{round(cell.value * 100, 1)}%</strong>
+      <div className="font-semibold">{cell.serieId}</div>
+      <div>
+        Week ending{' '}
+        <span className="font-semibold">
+          {format(cell.data.endOfWeek, 'EEEE do MMMM yyyy')}
+        </span>
+      </div>
+      <div>
+        Median usage:{' '}
+        <span className="font-semibold">{round(cell.value * 100, 1)}%</span>
+      </div>
     </div>
   );
 }

--- a/packages/PlanLimitsUI/src/pages/Usage/WeeklyResults.tsx
+++ b/packages/PlanLimitsUI/src/pages/Usage/WeeklyResults.tsx
@@ -47,7 +47,7 @@ function WeeklyUsageHeatMap({
         legend: 'Week ending',
         legendOffset: -70,
       }
-    : undefined;
+    : null;
 
   const marginTop = showWeeks ? 75 : 0;
   const marginBottom = showLegend ? 50 : 0;

--- a/packages/PlanLimitsUI/src/pages/Usage/WeeklyResults.tsx
+++ b/packages/PlanLimitsUI/src/pages/Usage/WeeklyResults.tsx
@@ -8,7 +8,11 @@ export default function WeeklyResults({ data }: { data: GroupedWaterUseData }) {
       <h2 className="text-xl mb-2">Weekly usage grouped by area</h2>
       {data.groups.map((usageGroup, index) => {
         return (
-          <div key={usageGroup.name} className="mb-6">
+          <div
+            id={`weekly-usage-${usageGroup.name}`}
+            key={usageGroup.name}
+            className="mb-6"
+          >
             {!usageGroup.hideLabel ? (
               <h2 className="text-lg mb-2">{usageGroup.name}</h2>
             ) : (
@@ -50,7 +54,7 @@ function WeeklyUsageHeatMap({
     <div className="w-full" style={{ height: `${height}px` }}>
       <ResponsiveHeatMapCanvas
         onClick={(cell) => {
-          window.location.href = `#daily-${cell.serieId}`;
+          window.location.href = `#daily-usage-${cell.serieId}`;
         }}
         tooltip={CustomTooltip}
         data={data}

--- a/packages/PlanLimitsUI/src/pages/Usage/WeeklyResults.tsx
+++ b/packages/PlanLimitsUI/src/pages/Usage/WeeklyResults.tsx
@@ -1,6 +1,7 @@
 import { ResponsiveHeatMapCanvas, type ComputedCell } from '@nivo/heatmap';
 import { format } from 'date-fns';
 import type { GroupedWaterUseData } from '../../lib/useDetailedWaterUseData';
+import { round } from 'lodash';
 
 export default function WeeklyResults({ data }: { data: GroupedWaterUseData }) {
   return (
@@ -79,18 +80,18 @@ function WeeklyUsageHeatMap({
   );
 }
 
-const CustomTooltip = ({
+function CustomTooltip({
   cell,
 }: {
   cell: ComputedCell<WeeklyUsageHeatmapDataItem>;
-}) => {
+}) {
   return (
     <div className="bg-gray-500 text-white opacity-90 text-xs p-2 rounded shadow">
       <span className="font-bold">{cell.serieId}</span>
       <br />
       Week ending {format(cell.data.endOfWeek, 'EEEE do MMMM yyyy')}
       <br />
-      Median usage: <strong>{cell.formattedValue}</strong>
+      Median usage: <strong>{round(cell.value, 1)}%</strong>
     </div>
   );
-};
+}

--- a/packages/PlanLimitsUI/src/pages/Usage/WeeklyResults.tsx
+++ b/packages/PlanLimitsUI/src/pages/Usage/WeeklyResults.tsx
@@ -12,17 +12,18 @@ export default function WeeklyResults({ data }: { data: GroupedWaterUseData }) {
           <div
             id={`weekly-usage-${usageGroup.name}`}
             key={usageGroup.name}
-            className="mb-6"
+            className="mb-4"
           >
             {!usageGroup.hideLabel ? (
-              <h2 className="text-lg mb-2">{usageGroup.name}</h2>
+              <h2 className="text-lg">{usageGroup.name}</h2>
             ) : (
               <></>
             )}
-            <div className="mb-4">
+            <div>
               <WeeklyUsageHeatMap
                 data={usageGroup.weeklyData}
                 showWeeks={index === 0}
+                showLegend={usageGroup.showLegend}
               ></WeeklyUsageHeatMap>
             </div>
           </div>
@@ -35,21 +36,24 @@ export default function WeeklyResults({ data }: { data: GroupedWaterUseData }) {
 function WeeklyUsageHeatMap({
   data,
   showWeeks,
+  showLegend,
 }: {
   data: HeatmapData[];
   showWeeks: boolean;
+  showLegend: boolean;
 }) {
   const axisTop = showWeeks
     ? {
         tickSize: 0,
         tickRotation: -50,
         legend: 'Week ending',
-        legendOffset: -65,
+        legendOffset: -70,
       }
     : undefined;
 
-  const marginTop = showWeeks ? 70 : 0;
-  const height = (data.length * 20 + marginTop).toString();
+  const marginTop = showWeeks ? 75 : 0;
+  const marginBottom = showLegend ? 50 : 0;
+  const height = (data.length * 16 + marginTop + marginBottom).toString();
 
   return (
     <div className="w-full" style={{ height: `${height}px` }}>
@@ -60,7 +64,7 @@ function WeeklyUsageHeatMap({
         tooltip={CustomTooltip}
         data={data}
         valueFormat={'=-0.0~%'}
-        margin={{ top: marginTop, right: 50, bottom: 0, left: 130 }}
+        margin={{ top: marginTop, right: 50, bottom: marginBottom, left: 130 }}
         colors={{
           type: 'sequential',
           scheme: 'oranges',
@@ -75,6 +79,19 @@ function WeeklyUsageHeatMap({
           tickSize: 0,
         }}
         animate={false}
+        legends={[
+          {
+            anchor: 'bottom',
+            direction: 'row',
+            translateY: 35,
+            title: 'Median usage (%) →',
+            length: 300,
+            titleOffset: 5,
+            titleAlign: 'middle',
+            thickness: 10,
+            tickFormat: '=-0.0~%',
+          },
+        ]}
       />
     </div>
   );

--- a/packages/PlanLimitsUI/src/pages/Usage/index.tsx
+++ b/packages/PlanLimitsUI/src/pages/Usage/index.tsx
@@ -1,11 +1,10 @@
 import { useAtom } from 'jotai';
-import { ResponsiveHeatMapCanvas, type ComputedCell } from '@nivo/heatmap';
-import { format } from 'date-fns';
-
 import { councilAtom } from '../../lib/loader';
 import useDetailedWaterUseData, {
   type DetailedWaterUseQuery,
 } from '../../lib/useDetailedWaterUseData';
+import WeeklyResults from './WeeklyResults';
+import DailyResults from './DailyResults';
 import Header from '../../pages/Limits/Sidebar/Header';
 import { ErrorIndicator, LoadingIndicator } from '../../components/Indicators';
 
@@ -32,7 +31,6 @@ export default function Usage() {
         </div>
       </div>
       <main className="p-4">
-        <h2 className="text-xl mb-2">Weekly usage grouped by area</h2>
         <Results waterUseData={waterUseData} />
       </main>
     </>
@@ -46,92 +44,15 @@ function Results({ waterUseData }: { waterUseData: DetailedWaterUseQuery }) {
   if (waterUseData.isError || !waterUseData.data || !waterUseData.data.usage) {
     return <ErrorIndicator>Error loading data</ErrorIndicator>;
   }
+
   return (
     <>
       <div className="mb-4 italic text-sm">
         No data for: {waterUseData.data.usage.allMissingAreas.join(', ')}
       </div>
-      {waterUseData.data.usage.groups.map((usageGroup, index) => {
-        return (
-          <div key={usageGroup.name} className="mb-6">
-            {!usageGroup.hideLabel ? (
-              <h2 className="text-lg mb-2">{usageGroup.name}</h2>
-            ) : (
-              <></>
-            )}
-            <div className="mb-4">
-              <WeeklyUsageHeatMap
-                data={usageGroup.data}
-                showWeeks={index === 0}
-              ></WeeklyUsageHeatMap>
-            </div>
-          </div>
-        );
-      })}
+
+      <WeeklyResults data={waterUseData.data.usage} />
+      <DailyResults data={waterUseData.data.usage} />
     </>
   );
 }
-
-function WeeklyUsageHeatMap({
-  data,
-  showWeeks,
-}: {
-  data: HeatmapData[];
-  showWeeks: boolean;
-}) {
-  const axisTop = showWeeks
-    ? {
-        tickSize: 0,
-        tickRotation: -50,
-        legend: 'Week ending',
-        legendOffset: -65,
-      }
-    : undefined;
-
-  const marginTop = showWeeks ? 70 : 0;
-  const height = (data.length * 20 + marginTop).toString();
-
-  return (
-    <div className="w-full" style={{ height: `${height}px` }}>
-      <ResponsiveHeatMapCanvas
-        onClick={(cell) => {
-          window.location.href = `#daily-${cell.serieId}`;
-        }}
-        tooltip={CustomTooltip}
-        data={data}
-        valueFormat={'=-0.0~%'}
-        margin={{ top: marginTop, right: 50, bottom: 0, left: 130 }}
-        colors={{
-          type: 'sequential',
-          scheme: 'oranges',
-          minValue: 0,
-          maxValue: 1,
-        }}
-        enableLabels={false}
-        axisTop={axisTop}
-        borderWidth={1}
-        borderColor={'#ddd'}
-        axisLeft={{
-          tickSize: 0,
-        }}
-        animate={false}
-      />
-    </div>
-  );
-}
-
-const CustomTooltip = ({
-  cell,
-}: {
-  cell: ComputedCell<WeeklyUsageHeatmapDataItem>;
-}) => {
-  return (
-    <div className="bg-gray-500 text-white opacity-90 text-xs p-2 rounded shadow">
-      <span className="font-bold">{cell.serieId}</span>
-      <br />
-      Week ending {format(cell.data.endOfWeek, 'EEEE do MMMM yyyy')}
-      <br />
-      Median usage: <strong>{cell.formattedValue}</strong>
-    </div>
-  );
-};

--- a/packages/PlanLimitsUI/src/pages/Usage/index.tsx
+++ b/packages/PlanLimitsUI/src/pages/Usage/index.tsx
@@ -20,7 +20,7 @@ export default function Usage() {
       <div className="flex justify-between items-end border-b">
         <div className="px-4 py-2">
           <a href={`/limits/${council.slug}`} className="text-xs underline">
-            Back to limits viewer
+            Back to allocations viewer
           </a>
           <h1 className="text-xl font-light uppercase mt-2">
             Detailed Water Usage
@@ -31,6 +31,11 @@ export default function Usage() {
         </div>
       </div>
       <main className="p-4">
+        <p className="mb-2">
+          The data below <strong>is not all Water Use data</strong> supplied to
+          Greater Wellington. It only includes data provided using timely
+          automated telemetered systems.
+        </p>
         <Results waterUseData={waterUseData} />
       </main>
     </>

--- a/packages/PlanLimitsUI/src/pages/Usage/index.tsx
+++ b/packages/PlanLimitsUI/src/pages/Usage/index.tsx
@@ -52,7 +52,11 @@ function Results({ waterUseData }: { waterUseData: DetailedWaterUseQuery }) {
       </div>
 
       <WeeklyResults data={waterUseData.data.usage} />
-      <DailyResults data={waterUseData.data.usage} />
+      <DailyResults
+        data={waterUseData.data.usage}
+        from={waterUseData.data.formattedFrom}
+        to={waterUseData.data.formattedTo}
+      />
     </>
   );
 }


### PR DESCRIPTION
This adds a daily water usage graph using the HeatMap component.

Something to consider and possibly improve - currently we're generating a daily heatmap for all areas on page loads, which might be render-intensive on some devices. We should check this, and consider rendering per-area in some kind of modal or reveal.