### PR TITLE
TEAMU-969 - Local run instructions in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,18 +35,25 @@ Include diagrams in the site:
 
 ### How to Run the application locally
 
-This is currently a slightly manual process.  In general, you will need at least the following installed on your machine:-
-* A [JVM](https://aws.amazon.com/corretto/?filtered-posts.sort-by=item.additionalFields.createdDate&filtered-posts.sort-order=desc) installed on the target machine.
-* [Docker](https://docs.docker.com/get-docker/) in order to run the [Batect](https://batect.dev/) tool.
+To run Ha Kākano locally, you will need to start the shared infrastructure services and then start the individual applications. 
+
+At least the following installed on your machine before you start:-
+* A [JVM](https://aws.amazon.com/corretto/?filtered-posts.sort-by=item.additionalFields.createdDate&filtered-posts.sort-order=desc) installed on the target machine in order to run the [Batect](https://batect.dev/) tool.
+* [Docker](https://docs.docker.com/get-docker/)
 * And of course a **git** tool of some sort to clone the repo to your machine
 
-With above in place, clone the repo to your machine and do the following from the command line in the root of your local repo to run the Plan Limits application:-
+Also, shared services will expose the following ports that will therefore also need to be available before you start:-
+* 5432 for Postgres
+* 8080 for the Manager API
+* 9092 for Kafka
+
+With above in place, clone the repo to your machine and do the following from a command line shell to start the shared services:-
 1. `cd packages/Manager`
 2. `./batect runSupportServices`
 
 _And from a new shell session in the same folder_
 
-3. `./gradew bootRun`
+3. `./gradlew bootRun`
 
 You have now started the shared infrastructure, and will find specific run instructions for each application package in its own README.md file.
 

--- a/README.md
+++ b/README.md
@@ -49,12 +49,11 @@ With above in place, clone the repo to your machine and do the following in the 
 3. Create a new shell session in the same folder
 4. `./gradew bootRun`
 5. In a new shell, go to `packages/PlanLimitUI`
-2. `./gradlew bootRun`
-3. npm install
-4. `cp .env.local.template .env.local`
-5. Go to (LINZ Basemaps)[https://basemaps.linz.govt.nz/@-41.8899962,174.0492437,z5) and get a 90 day API key
-6. Edit .env.local, adding your basemaps API key from the last step.  It should be be obvious where to insert it and should be a double-quoted string.
+6. npm install
+7. `cp .env.local.template .env.local`
+8. Go to (LINZ Basemaps)[https://basemaps.linz.govt.nz/@-41.8899962,174.0492437,z5) and get a 90 day API key
+9. Edit .env.local, adding your basemaps API key from the last step.  It should be be obvious where to insert it and should be a double-quoted string.
     eg, `VITE_LINZ_API_KEY="c01hnehzqpjbep1x6kgf8ey8wxw"`
-7. Ensure there are no instances of postgres running on your system
-8. `npm run dev`
-9. Visit http://localhost:5173/
+10. Ensure there are no instances of postgres running on your system
+11. `npm run dev`
+12. Visit http://localhost:5173/

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ With above in place, clone the repo to your machine and do the following in the 
 2. `./batect runSupportServices`
 3. Create a new shell session in the same folder
 4. `./gradew bootRun`
-5. `cd packages/PlanLimitUI`
+5. In a new shell, go to `packages/PlanLimitUI`
 2. `./gradlew bootRun`
 3. npm install
 4. `cp .env.local.template .env.local`

--- a/README.md
+++ b/README.md
@@ -43,8 +43,10 @@ This is currently a slightly manual process.  In general, you will need at least
 With above in place, clone the repo to your machine and do the following from the command line in the root of your local repo to run the Plan Limits application:-
 1. `cd packages/Manager`
 2. `./batect runSupportServices`
-_From a new shell session in the same folder_
-3`./gradew bootRun`
+
+_And from a new shell session in the same folder_
+
+3. `./gradew bootRun`
 
 You have now started the shared infrastructure, and will find specific run instructions for each application package in its own README.md file.
 

--- a/README.md
+++ b/README.md
@@ -33,3 +33,28 @@ Include diagrams in the site:
 * Update the relevant markdown file to incorporate diagrams into the site.
 * 
 * `git commit` changes
+
+### Run the application locally
+
+Running this application is fairly manual at the moment and requires some technical expertise.  In summary, you can run the application on your own computer by downloading it to your computer, setting up a few dependencies and executing a number of shell commands to start desired components. You will need on your machine:-
+* [postgres](https://www.postgresql.org/download/) installed on the target machine
+* [Docker](https://docs.docker.com/get-docker/)
+* [Node](https://nodejs.org/en/download/) to a GUI/front end application such as Plan Limits (which is a React application)
+* Java and [Gradle](https://gradle.org/install/)
+* And of course **git** to clone the repo to your machine
+
+With above in place, clone the repo to your machine and do the following in the root of your local repo to run the Plan Limits application:-
+1. `cd packages/Manager`
+2. `./batect runSupportServices`
+3. Create a new shell session in the same folder
+4. `./gradew bootRun`
+5. `cd packages/PlanLimitUI`
+2. `./gradlew bootRun`
+3. npm install
+4. `cp .env.local.template .env.local`
+5. Go to (LINZ Basemaps)[https://basemaps.linz.govt.nz/@-41.8899962,174.0492437,z5) and get a 90 day API key
+6. Edit .env.local, adding your basemaps API key from the last step.  It should be be obvious where to insert it and should be a double-quoted string.
+    eg, `VITE_LINZ_API_KEY="c01hnehzqpjbep1x6kgf8ey8wxw"`
+7. Ensure there are no instances of postgres running on your system
+8. `npm run dev`
+9. Visit http://localhost:5173/

--- a/README.md
+++ b/README.md
@@ -37,12 +37,14 @@ Include diagrams in the site:
 
 To run Ha Kākano locally, you will need to start the shared infrastructure services and then start the individual applications. 
 
-At least the following installed on your machine before you start:-
+#### Shared Infrastructure
+
+You will need at least the following installed on your machine before you start:-
 * A [JVM](https://aws.amazon.com/corretto/?filtered-posts.sort-by=item.additionalFields.createdDate&filtered-posts.sort-order=desc) installed on the target machine in order to run the [Batect](https://batect.dev/) tool.
 * [Docker](https://docs.docker.com/get-docker/)
 * And of course a **git** tool of some sort to clone the repo to your machine
 
-Also, shared services will expose the following ports that will therefore also need to be available before you start:-
+Shared services will expose the following ports that will need to be available before you start:-
 * 5432 for Postgres
 * 8080 for the Manager API
 * 9092 for Kafka
@@ -55,6 +57,6 @@ _And from a new shell session in the same folder_
 
 3. `./gradlew bootRun`
 
-You have now started the shared infrastructure, and will find specific run instructions for each application package in its own README.md file.
+#### Application Packages
 
-For example, [here are the run instructions for the Plan Limits UI](packages/PlanLimitsUI/README.md).
+Having started the shared infrastructure, you will find specific run instructions for each application package in its own README.md file.  For example, [here are the run instructions for the Plan Limits UI](packages/PlanLimitsUI/README.md).

--- a/README.md
+++ b/README.md
@@ -31,29 +31,21 @@ Include diagrams in the site:
 * Export diagrams via http://localhost:8090
 * Save exported diagrams to the relevant folder in `src/markdown-pages`
 * Update the relevant markdown file to incorporate diagrams into the site.
-* 
 * `git commit` changes
 
-### Run the application locally
+### How to Run the application locally
 
-Running this application is fairly manual at the moment and requires some technical expertise.  In summary, you can run the application on your own computer by downloading it to your computer, setting up a few dependencies and executing a number of shell commands to start desired components. You will need on your machine:-
-* [postgres](https://www.postgresql.org/download/) installed on the target machine
-* [Docker](https://docs.docker.com/get-docker/)
-* [Node](https://nodejs.org/en/download/) to a GUI/front end application such as Plan Limits (which is a React application)
-* Java and [Gradle](https://gradle.org/install/)
-* And of course **git** to clone the repo to your machine
+This is currently a slightly manual process.  In general, you will need at least the following installed on your machine:-
+* A [JVM](https://aws.amazon.com/corretto/?filtered-posts.sort-by=item.additionalFields.createdDate&filtered-posts.sort-order=desc) installed on the target machine.
+* [Docker](https://docs.docker.com/get-docker/) in order to run the [Batect](https://batect.dev/) tool.
+* And of course a **git** tool of some sort to clone the repo to your machine
 
-With above in place, clone the repo to your machine and do the following in the root of your local repo to run the Plan Limits application:-
+With above in place, clone the repo to your machine and do the following from the command line in the root of your local repo to run the Plan Limits application:-
 1. `cd packages/Manager`
 2. `./batect runSupportServices`
-3. Create a new shell session in the same folder
-4. `./gradew bootRun`
-5. In a new shell, go to `packages/PlanLimitUI`
-6. npm install
-7. `cp .env.local.template .env.local`
-8. Go to (LINZ Basemaps)[https://basemaps.linz.govt.nz/@-41.8899962,174.0492437,z5) and get a 90 day API key
-9. Edit .env.local, adding your basemaps API key from the last step.  It should be be obvious where to insert it and should be a double-quoted string.
-    eg, `VITE_LINZ_API_KEY="c01hnehzqpjbep1x6kgf8ey8wxw"`
-10. Ensure there are no instances of postgres running on your system
-11. `npm run dev`
-12. Visit http://localhost:5173/
+_From a new shell session in the same folder_
+3`./gradew bootRun`
+
+You have now started the shared infrastructure, and will find specific run instructions for each application package in its own README.md file.
+
+For example, [here are the run instructions for the Plan Limits UI](packages/PlanLimitsUI/README.md).

--- a/packages/PlanLimitsUI/README.md
+++ b/packages/PlanLimitsUI/README.md
@@ -1,0 +1,14 @@
+
+## Plan Limits UI
+
+The Plan Limits UI is a front end application that allows users to view and manage water use limits. It is built using React and relies on the Ha Kākano shared data services to be running in the background. Therefore, to run this application locally, you will need to first start the supporting services which you can do by following the [instructions in the main readme](../../README.md).  Then do the following to serve this application to your browser:-
+
+In a command line shell in the `packages/PlanLimitUI` folder:-
+1. Run `npm install`
+2. Run `cp .env.local.template .env.local`
+3. Go to (LINZ Basemaps)[https://basemaps.linz.govt.nz/@-41.8899962,174.0492437,z5) and get a 90 day API key
+4. if you haven't done so already, or your existing key is no longer valid, edit .env.local, adding your basemaps API key from the last step.  It should be be obvious where to insert it and should be a double-quoted string.
+   eg, `VITE_LINZ_API_KEY="c01ehzsqpjbep1x6akgf8ey8wxw"`
+5. Run `npm run dev`
+
+You can now visit http://localhost:5173/ to see the Plan Limits UI.

--- a/packages/PlanLimitsUI/README.md
+++ b/packages/PlanLimitsUI/README.md
@@ -1,7 +1,7 @@
 
 ## Plan Limits UI
 
-The Plan Limits UI is a front end application that allows users to view and manage water use limits. It is built using React and relies on the Ha Kākano shared data services to be running in the background. Therefore, to run this application locally, you will need to first start the supporting services which you can do by following the [instructions in the main readme](../../README.md).  Then do the following to serve this application to your browser:-
+The Plan Limits UI is a front end application that allows users to view water use limits. It is built using React and relies on the Ha Kākano shared data services to be running in the background. Therefore, to run this application locally, you will need to first start the supporting services which you can do by following the [instructions in the main readme](../../README.md).  Then do the following to serve this application to your browser:-
 
 In a command line shell in the `packages/PlanLimitUI` folder:-
 1. Run `npm install`

--- a/packages/PlanLimitsUI/README.md
+++ b/packages/PlanLimitsUI/README.md
@@ -5,10 +5,16 @@ The Plan Limits UI is a front end application that allows users to view and mana
 
 In a command line shell in the `packages/PlanLimitUI` folder:-
 1. Run `npm install`
+
+_The following steps (2 to 4) are only required once, or if your LINZ Basemaps key has expired._
+
 2. Run `cp .env.local.template .env.local`
 3. Go to (LINZ Basemaps)[https://basemaps.linz.govt.nz/@-41.8899962,174.0492437,z5) and get a 90 day API key
-4. if you haven't done so already, or your existing key is no longer valid, edit .env.local, adding your basemaps API key from the last step.  It should be be obvious where to insert it and should be a double-quoted string.
+4. Edit .env.local, adding your basemaps API key from the last step.  It should be be obvious where to insert it and should be a double-quoted string.
    eg, `VITE_LINZ_API_KEY="c01ehzsqpjbep1x6akgf8ey8wxw"`
+
+_And start the server_
+
 5. Run `npm run dev`
 
 You can now visit http://localhost:5173/ to see the Plan Limits UI.


### PR DESCRIPTION
A first bash at adding local run instructions to the EOP readme.  Manual and technical for now, but a starting point from which to improve. Some automation can be added as we go.