### PR TITLE
Adding calc so ruamahanga total allocation will display

### DIFF
--- a/packages/Manager/src/main/resources/db/migration/V0044__water_allocation_by_area_add_ruamahanga.sql
+++ b/packages/Manager/src/main/resources/db/migration/V0044__water_allocation_by_area_add_ruamahanga.sql
@@ -1,0 +1,31 @@
+CREATE
+OR REPLACE VIEW water_allocations_by_area (area_id, allocation_amount) AS
+SELECT
+  area_id,
+  sum(allocation_plan) as allocation_amount
+FROM
+  water_allocations
+WHERE
+  effective_to is null
+GROUP BY
+  area_id
+
+UNION ALL
+
+SELECT
+'RuamahangaTotalSW' AS area_id
+, sum(allocation_plan) as allocation_amount
+FROM water_allocations
+WHERE area_id IN (
+'BoothsSW',
+'HuangaruaSW',
+'KopuarangaSW',
+'MangatarereSW',
+'PapawaiSW',
+'ParkvaleSW',
+'Ruamahanga_LowerSW',
+'Ruamahanga_MiddleSW',
+'Ruamahanga_UpperSW',
+'WaingawaSW',
+'WaiohineSW',
+'WaipouaSW')


### PR DESCRIPTION
Adding calc so ruamahanga will display a core consented allocation.

This had previously calculated by Dagster prior
to sending the data to EOP.

Now that EOP aggregates data from consent level
data, it needs to aggregrate data to this group.