### PR TITLE
Creating model for the REC2 boundaries

### DIFF
--- a/packages/DataTransformation/models/marts/planLimits/council_plan_rec2_boundaries.sql
+++ b/packages/DataTransformation/models/marts/planLimits/council_plan_rec2_boundaries.sql
@@ -1,0 +1,59 @@
+WITH
+RECURSIVE
+input AS (
+  SELECT
+    council_id,
+    source_id,
+    hydro_ids,
+    excluded_hydro_ids
+  FROM
+    {{ ref('stg_council_plan_boundary_rec2_source') }}
+),
+
+expanded_input AS (
+  SELECT
+    council_id,
+    source_id,
+    UNNEST(hydro_ids) AS hydro_id
+  FROM
+    input
+),
+
+all_hydro_ids AS (
+  SELECT *
+  FROM
+    expanded_input
+  UNION ALL
+  SELECT
+    a.council_id,
+    a.source_id,
+    rv.hydro_id
+  FROM
+    {{ ref('rivers') }} AS rv
+  INNER JOIN all_hydro_ids AS a ON rv.next_hydro_id = a.hydro_id
+),
+
+with_watershed_geom AS (
+  SELECT
+    a.council_id,
+    a.source_id,
+    a.hydro_id,
+    w.geom
+  FROM
+    all_hydro_ids AS a
+  INNER JOIN watersheds AS w ON a.hydro_id = w.hydro_id
+),
+
+as_grouped_boundaries AS (
+  SELECT
+    council_id,
+    source_id,
+    ST_UNION(geom) AS geom
+  FROM
+    with_watershed_geom
+  GROUP BY council_id, source_id
+)
+
+SELECT *
+FROM
+  as_grouped_boundaries

--- a/packages/DataTransformation/models/staging/planLimits/_planLimits_sources.yml
+++ b/packages/DataTransformation/models/staging/planLimits/_planLimits_sources.yml
@@ -1,0 +1,50 @@
+version: 2
+
+sources:
+  - name: public
+    tables:
+      - name: council_plan_boundary_geojson_source
+        description: "Reference table for council boundaries that are sourced from a URL that returns GeoJson"
+        columns:
+          - name: id
+            data_type: integer
+            description: "unique id"
+          - name: council_id
+            data_type: integer
+            description: "ID of the council"
+          - name: source_id
+            data_type: character varying
+            description: "ID of the source"
+          - name: url
+            data_type: character varying
+            description: "URL to fetch the GeoJson"
+          - name: feature_id
+            data_type: character varying
+            description: "feature id in the resulting GeoJson to use as this boundary"
+          - name: created_at
+            data_type: timestamp with time zone
+          - name: updated_at
+            data_type: timestamp with time zone
+
+      - name: council_plan_boundary_rec2_source
+        description: "Reference table for council boundaries that are sourced from the REC2 model based on river segments and watershed"
+        columns:
+          - name: id
+            data_type: integer
+            description: "unique id"
+          - name: council_id
+            data_type: integer
+            description: "ID of the council"
+          - name: source_id
+            data_type: character varying
+            description:  "ID of the source"
+          - name: hydro_ids
+            data_type: array
+            description: "the hydro ids at the base of the boundary"
+          - name: excluded_hydro_ids
+            data_type: array
+            description: "the hydro ids to exclude going past when creating the boundary"
+          - name: created_at
+            data_type: timestamp with time zone
+          - name: updated_at
+            data_type: timestamp with time zone

--- a/packages/DataTransformation/models/staging/planLimits/stg_council_plan_boundary_geojson_source.sql
+++ b/packages/DataTransformation/models/staging/planLimits/stg_council_plan_boundary_geojson_source.sql
@@ -1,0 +1,17 @@
+WITH source AS (
+
+  SELECT * FROM {{ source('public', 'council_plan_boundary_geojson_source') }}
+
+)
+
+
+SELECT
+  id,
+  council_id,
+  source_id,
+  url,
+  feature_id,
+  created_at,
+  updated_at
+
+FROM source

--- a/packages/DataTransformation/models/staging/planLimits/stg_council_plan_boundary_rec2_source.sql
+++ b/packages/DataTransformation/models/staging/planLimits/stg_council_plan_boundary_rec2_source.sql
@@ -1,0 +1,17 @@
+WITH source AS (
+
+  SELECT * FROM {{ source('public', 'council_plan_boundary_rec2_source') }}
+
+)
+
+
+SELECT
+  id,
+  council_id,
+  source_id,
+  hydro_ids,
+  excluded_hydro_ids,
+  created_at,
+  updated_at
+
+FROM source


### PR DESCRIPTION
This just creates a table with the boundaries described in `council_plan_boundary_rec2_source`. More work needs to be done to get the values from here into the `council_plan_boundaries` table.