### PR TITLE
add docs-site to dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -44,4 +44,13 @@ updates:
     open-pull-requests-limit: 2    
     labels:
       - "npm"
-      - "dependencies"      
+      - "dependencies"
+
+  - package-ecosystem: "npm"
+    directory: "/docs-site"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 2    
+    labels:
+      - "npm"
+      - "dependencies"


### PR DESCRIPTION
This will turn on npm dependabot monitoring for the docs-site