### PR TITLE
exclude inactive and non current records for consented_allocations calcs

### DIFF
--- a/packages/DataTransformation/models/marts/planlimits/water_allocations_by_area.sql
+++ b/packages/DataTransformation/models/marts/planlimits/water_allocations_by_area.sql
@@ -16,7 +16,10 @@ water_allocations_by_area AS (
 
   FROM water_allocations
   WHERE
-    effective_to IS NULL
+    effective_to IS NULL 
+  AND 
+    status = 'active'
+  
   GROUP BY 1
 
 ),
@@ -43,6 +46,10 @@ water_allocations_ruamahangasw AS (
     'WaiohineSW',
     'WaipouaSW'
   )
+  AND
+    effective_to IS NULL
+  AND 
+    status = 'active'
 
 )
 


### PR DESCRIPTION
consented_allocation (allocation_plan) data was not correct for several areas because inactivated consents were getting included in calculations. 

In addition, consents that had an effective_to date specified were getting included in the ruamahanga surface water calculation. this is wrong as an effective_to date means that the record is not current, and should be excluded.