### PR TITLE
add github actions to dependabot checks

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -63,3 +63,9 @@ updates:
     labels:
       - "npm"
       - "dependencies"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 2


### PR DESCRIPTION
This will add a dependabot check for our 'actions' in our github actions workflows