### PR TITLE
Revert "Bump @types/node from 20.17.6 to 22.9.0 in /packages/cccv"

### DIFF
--- a/packages/cccv/package.json
+++ b/packages/cccv/package.json
@@ -64,7 +64,7 @@
     "@testing-library/react": "^16.0.1",
     "@testing-library/user-event": "^14.5.2",
     "@types/dompurify": "^3.0.5",
-    "@types/node": "^22.9.0",
+    "@types/node": "^20.11.24",
     "@types/react": "^18.2.56",
     "@types/react-dom": "^18.2.19",
     "@types/testing-library__user-event": "^4.2.0",


### PR DESCRIPTION
Reverts Greater-Wellington-Regional-Council/Environmental-Outcomes-Platform#479