### PR TITLE
manage flyway deps as a group

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,7 +8,11 @@ updates:
     open-pull-requests-limit: 5
     labels:
       - "gradle"
-      - "dependencies"      
+      - "dependencies"
+    groups:
+       flyway-deps:
+          patterns:
+            - "org.flyway*"     
       
   - package-ecosystem: "gradle"
     directory: "/packages/IngestAPI"
@@ -26,7 +30,11 @@ updates:
     open-pull-requests-limit: 10
     labels:
       - "gradle"
-      - "dependencies"      
+      - "dependencies"
+    groups:
+       flyway-deps:
+          patterns:
+            - "org.flyway*"       
 
   - package-ecosystem: "npm"
     directory: "/packages/PlanLimitsUI"


### PR DESCRIPTION
This change will mean that dependabot groups all flyway updates into one dependabot PR. 