### PR TITLE
TEAMU-1298 fix Incorrect flow mgmt site being referenced

### DIFF
--- a/packages/PlanLimitsUI/src/pages/Limits/map.tsx
+++ b/packages/PlanLimitsUI/src/pages/Limits/map.tsx
@@ -64,7 +64,7 @@ function mapFeatureLayer<T extends Identifyable>(
   collection: T[],
 ) {
   const featureLayers = mapFeatureLayers<T>(features, layerName, collection)
-  return featureLayers[layerName === "surfaceWaterSubUnitLimits" ? featureLayers.length - 1 : 0];
+  return featureLayers[["surfaceWaterSubUnitLimits", "flowLimits"].includes(layerName) ? featureLayers.length - 1 : 0];
 }
 
 function mapAllFeatures(


### PR DESCRIPTION
This fixes an issue where the wrong layer was getting selected for flow limits. This issue has previously been fixed for surfacewater management units and extends the fix to cover flow limits too.