### PR TITLE
TEAMU-1727 Bug fix for incorrect numbers shown on allocation table

### DIFF
--- a/packages/DataTransformation/models/marts/planlimits/groundwater_allocation_limits_by_area_and_category.sql
+++ b/packages/DataTransformation/models/marts/planlimits/groundwater_allocation_limits_by_area_and_category.sql
@@ -14,22 +14,39 @@ WITH water_allocations AS (
 
      ),
 
-     water_allocations_at_month_start AS(
+    generate_month_ends AS (
+        SELECT 
+            month_start,
+            (month_start + INTERVAL '1 month' - INTERVAL '1 day') AS month_end
+        FROM generate_months
+    ),
 
-         SELECT
-
-             m.month_start,
-             w.*
-         FROM
-             generate_months m
-
-                 LEFT JOIN
-             water_allocations w
-             ON
-                 w.effective_from <= m.month_start
-                     AND (w.effective_to IS NULL OR w.effective_to > m.month_start)
-
-     ),
+     water_allocations_at_month_end AS (
+        SELECT
+            m.month_start,
+            m.month_end,
+            t.*
+        FROM generate_month_ends m
+        LEFT JOIN water_allocations t
+            ON 
+                ( 
+                    -- For past and future months: effective_from <= month_end
+                    t.effective_from <= m.month_end
+                    -- For the current month: effective_from must be <= today
+                    OR (m.month_end = (DATE_TRUNC('month', CURRENT_DATE) + INTERVAL '1 month' - INTERVAL '1 day') 
+                        AND t.effective_from <= CURRENT_DATE)
+                )
+                AND 
+                (
+                    -- Keep records where effective_to is NULL or after the month end
+                    t.effective_to IS NULL OR t.effective_to > m.month_end
+                )
+                -- Exclude records where effective_to is before today in the current month
+                AND NOT (
+                    m.month_end = (DATE_TRUNC('month', CURRENT_DATE) + INTERVAL '1 month' - INTERVAL '1 day') 
+                    AND t.effective_to < CURRENT_DATE
+                )
+    ),
 
      ground_water_limits AS (
 
@@ -44,7 +61,7 @@ WITH water_allocations AS (
              category,
              SUM(allocation_plan) AS allocation_amount
 
-         FROM water_allocations_at_month_start
+         FROM water_allocations_at_month_end
          WHERE
              status = 'active'
            AND category IN ('B', 'C', 'B/C') AND area_id LIKE ('%GW')

--- a/packages/DataTransformation/models/marts/planlimits/surfacewater_allocation_limits_by_area_and_category.sql
+++ b/packages/DataTransformation/models/marts/planlimits/surfacewater_allocation_limits_by_area_and_category.sql
@@ -14,35 +14,39 @@ WITH water_allocations AS (
 
      ),
 
-     water_allocations_at_month_start AS(
+    generate_month_ends AS (
+        SELECT 
+            month_start,
+            (month_start + INTERVAL '1 month' - INTERVAL '1 day') AS month_end
+        FROM generate_months
+    ),
 
-         SELECT
-
-             m.month_start,
-             t.*
-         FROM
-             generate_months m
-
-                 LEFT JOIN
-             water_allocations t
-             ON 
+     water_allocations_at_month_end AS (
+        SELECT
+            m.month_start,
+            m.month_end,
+            t.*
+        FROM generate_month_ends m
+        LEFT JOIN water_allocations t
+            ON 
                 ( 
-                    -- For past and future months: effective_from <= month_start
-                    t.effective_from <= m.month_start
+                    -- For past and future months: effective_from <= month_end
+                    t.effective_from <= m.month_end
                     -- For the current month: effective_from must be <= today
-                    OR (m.month_start = DATE_TRUNC('month', CURRENT_DATE) AND t.effective_from <= CURRENT_DATE)
+                    OR (m.month_end = (DATE_TRUNC('month', CURRENT_DATE) + INTERVAL '1 month' - INTERVAL '1 day') 
+                        AND t.effective_from <= CURRENT_DATE)
                 )
                 AND 
                 (
-                    -- Keep records where effective_to is NULL or after the month start
-                    t.effective_to IS NULL OR t.effective_to > m.month_start
+                    -- Keep records where effective_to is NULL or after the month end
+                    t.effective_to IS NULL OR t.effective_to > m.month_end
                 )
                 -- Exclude records where effective_to is before today in the current month
                 AND NOT (
-                    m.month_start = DATE_TRUNC('month', CURRENT_DATE) 
+                    m.month_end = (DATE_TRUNC('month', CURRENT_DATE) + INTERVAL '1 month' - INTERVAL '1 day') 
                     AND t.effective_to < CURRENT_DATE
                 )
-     ),
+    ),
 
      surface_water_limits AS (
 
@@ -57,9 +61,9 @@ WITH water_allocations AS (
              category,
              SUM(allocation_plan) AS allocation_amount
 
-         FROM water_allocations_at_month_start
+         FROM water_allocations_at_month_end
          WHERE
-             effective_to IS NULL AND status = 'active'
+             status = 'active'
            AND category IN ('A', 'B', 'ST') AND area_id LIKE ('%SW')
 
          GROUP BY 1, 2, 3


### PR DESCRIPTION
allocation table figures were showing data as at the first of the month, instead of what was expected, which is that the current month displays any consent change that has occurred in the month. 

This PR adds some more logic to:

- for the current month, you see allocation figures for the current day you are viewing them.
- for previous months you are seeing allocation figures for the last day of that month.

