### PR TITLE
Fix to PLV to reflect Lake Wairarapa surface water grouping correctly

### DIFF
--- a/packages/DataTransformation/README.md
+++ b/packages/DataTransformation/README.md
@@ -1,6 +1,6 @@
 # Data Transformations
 
-TODO - this is super quick doc so it can be shared while work is sitll going on
+TODO - this is super quick doc so it can be shared while work is still going on
 
 ## Running
 
@@ -34,7 +34,7 @@ This will allow JOOQ to generate classes before DBT has run
 
 ### Generate DBT documentation
 
-The command helps in generating your project's documentation and catelog will be created.
+The command helps in generating your project's documentation and catalog will be created.
 
 * `./batect generate-docs`
 

--- a/packages/DataTransformation/models/marts/planlimits/surfacewater_allocation_limits_by_area_and_category.sql
+++ b/packages/DataTransformation/models/marts/planlimits/surfacewater_allocation_limits_by_area_and_category.sql
@@ -82,6 +82,57 @@ WITH water_allocations AS (
 
          FROM surfacewater_allocations group by 1, 2
 
+     ),
+
+    lake_wairarapa_totals AS (
+         SELECT
+             month_start,
+            'LakeWairarapaTotalSW' AS area_id,
+             COALESCE(SUM(CASE WHEN category = 'A' THEN allocation_amount END), 0) AS category_A,
+             COALESCE(SUM(CASE WHEN category = 'B' THEN allocation_amount END), 0) AS category_B,
+             COALESCE(SUM(CASE WHEN category = 'ST' THEN allocation_amount END), 0) AS surface_take,
+             COALESCE(SUM(CASE WHEN category IN ('A', 'B','ST') THEN allocation_amount END), 0) AS total_allocation
+         FROM surfacewater_allocations
+         WHERE area_id IN (
+            'LakeWairarapaSW',
+            'OtukuraSW',
+            'TauherenikauSW'
+            )
+         GROUP BY 1, 2
+     ),
+
+    ruamahanga_totals AS (
+         SELECT
+             month_start,
+            'RuamahangaTotalSW' AS area_id,
+             COALESCE(SUM(CASE WHEN category = 'A' THEN allocation_amount END), 0) AS category_A,
+             COALESCE(SUM(CASE WHEN category = 'B' THEN allocation_amount END), 0) AS category_B,
+             COALESCE(SUM(CASE WHEN category = 'ST' THEN allocation_amount END), 0) AS surface_take,
+             COALESCE(SUM(CASE WHEN category IN ('A', 'B','ST') THEN allocation_amount END), 0) AS total_allocation
+         FROM surfacewater_allocations
+         WHERE area_id IN (
+            'BoothsSW',
+            'HuangaruaSW',
+            'KopuarangaSW',
+            'MangatarereSW',
+            'PapawaiSW',
+            'ParkvaleSW',
+            'Ruamahanga_LowerSW',
+            'Ruamahanga_MiddleSW',
+            'Ruamahanga_UpperSW',
+            'WaingawaSW',
+            'WaiohineSW',
+            'WaipouaSW'
+        )
+         GROUP BY 1, 2
+     ),
+
+surfacewater_allocation_by_area_and_category_with_totals AS (
+         SELECT * FROM surfacewater_allocation_by_area_and_category
+         UNION ALL
+         SELECT * FROM lake_wairarapa_totals
+         UNION ALL
+         SELECT * FROM ruamahanga_totals
      )
 
 SELECT
@@ -98,6 +149,6 @@ SELECT
     swl.name,
     swl.plan_region_id
 
-FROM surfacewater_allocation_by_area_and_category sw
+FROM surfacewater_allocation_by_area_and_category_with_totals sw
          LEFT JOIN surface_water_limits swl
                    ON swl.source_id = sw.area_id

--- a/packages/DataTransformation/models/marts/planlimits/water_allocations_by_area.sql
+++ b/packages/DataTransformation/models/marts/planlimits/water_allocations_by_area.sql
@@ -51,8 +51,30 @@ water_allocations_ruamahangasw AS (
   AND 
     status = 'active'
 
+),
+
+water_allocations_lakewairarapasw AS (
+
+  SELECT
+
+    'LakeWairarapaTotalSW' AS area_id,
+    SUM(allocation_plan) AS allocation_amount
+  FROM water_allocations
+
+  WHERE area_id IN (
+    'LakeWairarapaSW',
+    'OtukuraSW',
+    'TauherenikauSW'
+  )
+  AND
+    effective_to IS NULL
+  AND 
+    status = 'active'
+
 )
 
 SELECT * FROM water_allocations_by_area
 UNION ALL
 SELECT * FROM water_allocations_ruamahangasw
+UNION ALL
+SELECT * FROM water_allocations_lakewairarapasw

--- a/packages/Manager/src/main/kotlin/nz/govt/eop/tasks/CouncilPlanBoundariesGeoJsonFetcher.kt
+++ b/packages/Manager/src/main/kotlin/nz/govt/eop/tasks/CouncilPlanBoundariesGeoJsonFetcher.kt
@@ -33,7 +33,7 @@ class CouncilPlanBoundariesGeoJsonFetcher(
 
   private fun updateCouncilPlanGeoJsonBoundaries() {
     // Expect multiple rows to pull from the same source URL, so cache the results for the length of
-    // this execution
+    // this execution.
     jdbcTemplate.queryForList("SELECT * FROM council_plan_boundary_geojson_source").forEach {
       val councilId = it["council_id"] as Int
       val sourceId = it["source_id"] as String

--- a/packages/Manager/src/main/resources/db/migration/R__2_gwrc_plan_data.sql
+++ b/packages/Manager/src/main/resources/db/migration/R__2_gwrc_plan_data.sql
@@ -1293,7 +1293,7 @@ VALUES
                   "allocationLimit": 7430
                 },
                 {
-                  "id": "LakeWairarapaSW",
+                  "id": "LakeWairarapaTotalSW",
                   "name": "Lake Wairarapa and tributaries above the confluence of the Lake Wairarapa outflow with the Ruamāhanga River",
                   "children": [
                     {


### PR DESCRIPTION
The lake wairarapa surface water area previously only included consented allocation data for LakeWairarapaSW consents, and did not include 'OtukuraSW' or 'TauherenikauSW' figures. This PR 

- Creates a new grouping LakeWairarapaTotalSW that does contain the three areas
- aggregates consented allocations from the three areas into this group
- changes the NRP document to reference this group (so that the map uses the group for displaying consented allocations)
- Uses this aggregated group and adds RuamahangaTotalSW to the allocations table.

