### PR TITLE
remove space from Lower ruamanga gw plan id

### DIFF
--- a/packages/Manager/src/main/resources/db/migration/R__2_gwrc_plan_data.sql
+++ b/packages/Manager/src/main/resources/db/migration/R__2_gwrc_plan_data.sql
@@ -522,7 +522,7 @@ VALUES
                   "allocationLimit": 6750000
                 },
                 {
-                  "id": "Lower RuamahangaGW",
+                  "id": "LowerRuamahangaGW",
                   "name": "Lower Ruamāhanga",
                   "areas": [
                     {


### PR DESCRIPTION
fix for lower ruamahangaGW allocation not appearing on the allocation table